### PR TITLE
Desmear noise comp

### DIFF
--- a/bliss/core/coarse_channel.cpp
+++ b/bliss/core/coarse_channel.cpp
@@ -40,8 +40,6 @@ coarse_channel::coarse_channel(bland::ndarray data,
         _data_type(data_type),
         _az_start(az_start),
         _za_start(za_start) {
-    // TODO: compute/extract this somewhere more authoritative
-    _integration_length = data.size(0);
 }
 
 bland::ndarray bliss::coarse_channel::data() const {
@@ -181,54 +179,10 @@ double bliss::coarse_channel::za_start() const {
 //     _za_start = za_start;
 // }
 
-bool bliss::coarse_channel::has_doppler_spectrum() {
-    return _dedrifted_spectrum.has_value();
+frequency_drift_plane bliss::coarse_channel::integrated_drift_plane() {
+    return _integrated_drift_plane.value();
 }
 
-bland::ndarray &bliss::coarse_channel::doppler_spectrum() {
-    if (_dedrifted_spectrum.has_value()) {
-        return _dedrifted_spectrum.value();
-    } else {
-        throw std::runtime_error("dedrifted_spectrum: have not computed dedrifted spectrum yet");
-    }
-}
-
-void bliss::coarse_channel::doppler_spectrum(bland::ndarray doppler_spectrum) {
-    _dedrifted_spectrum = doppler_spectrum;
-}
-
-integrated_flags &bliss::coarse_channel::doppler_flags() {
-    if (_dedrifted_rfi.has_value()) {
-        return _dedrifted_rfi.value();
-    } else {
-        throw std::runtime_error("doppler_flags (getter): have not computed dedrifted flags");
-    }
-}
-
-void bliss::coarse_channel::doppler_flags(integrated_flags doppler_flags) {
-    _dedrifted_rfi = doppler_flags;
-}
-
-integrate_drifts_options bliss::coarse_channel::dedoppler_options() {
-    if (_drift_parameters.has_value()) {
-        return _drift_parameters.value();
-    } else {
-        throw std::runtime_error("dedoppler_options (getter): have not computed dedrifted spectrum yet");
-    }
-}
-
-void bliss::coarse_channel::dedoppler_options(integrate_drifts_options dedoppler_options) {
-    _drift_parameters = dedoppler_options;
-}
-
-int64_t bliss::coarse_channel::integration_length() {
-    if (_integration_length.has_value()) {
-        return _integration_length.value();
-    } else {
-        throw std::runtime_error("_integration_length: have not computed dedrifted spectrum yet");
-    }
-}
-
-void bliss::coarse_channel::integration_length(int64_t length) {
-    _integration_length = length;
+void bliss::coarse_channel::set_integrated_drift_plane(frequency_drift_plane integrated_plane) {
+    _integrated_drift_plane = integrated_plane;
 }

--- a/bliss/core/include/core/coarse_channel.hpp
+++ b/bliss/core/include/core/coarse_channel.hpp
@@ -4,6 +4,7 @@
 
 #include "noise_power.hpp"
 #include "integrate_drifts_options.hpp"
+#include "frequency_drift_plane.hpp"
 #include "hit.hpp"
 
 #include <list>
@@ -38,15 +39,8 @@ struct coarse_channel {
     bland::ndarray mask() const;
     void           set_mask(bland::ndarray new_mask);
 
-    bool                    has_doppler_spectrum();
-    bland::ndarray          &doppler_spectrum();
-    void                     doppler_spectrum(bland::ndarray doppler_spectrum);
-    integrated_flags        &doppler_flags();
-    void                     doppler_flags(integrated_flags doppler_flags);
-    integrate_drifts_options dedoppler_options();
-    void                     dedoppler_options(integrate_drifts_options dedoppler_options);
-    int64_t                  integration_length();
-    void                     integration_length(int64_t);
+    frequency_drift_plane integrated_drift_plane();
+    void set_integrated_drift_plane(frequency_drift_plane integrated_plane);
 
     noise_stats noise_estimate() const;
     void        set_noise_estimate(noise_stats estimate);
@@ -109,9 +103,14 @@ struct coarse_channel {
 
     std::optional<noise_stats> _noise_stats;
 
-    std::optional<int64_t>                  _integration_length;
+    std::optional<frequency_drift_plane> _integrated_drift_plane;
+
     std::optional<bland::ndarray>           _dedrifted_spectrum;
     std::optional<integrated_flags>         _dedrifted_rfi;
+
+
+    // TODO: I do not think we need to carry this around anymore since we'll track everything needed
+    // in the frequency_drift_plane object
     std::optional<integrate_drifts_options> _drift_parameters;
 
     std::optional<std::list<hit>> _hits;

--- a/bliss/core/include/core/frequency_drift_plane.hpp
+++ b/bliss/core/include/core/frequency_drift_plane.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <bland/ndarray.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace bliss {
+
+struct frequency_drift_plane {
+    struct drift_rate {
+            int index_in_plane;
+            double drift_rate_slope = 0.0F;
+            double drift_rate_Hz_per_sec = 0.0F;
+            int desmeared_bins=1; // number of bins per spectra used to desmear
+    };
+
+    frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi) : _integrated_drifts(drift_plane), _dedrifted_rfi(drift_rfi) {}
+    frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi, int64_t integration_steps, std::vector<drift_rate> dri) : 
+        _integrated_drifts(drift_plane), _dedrifted_rfi(drift_rfi), _integration_steps(integration_steps), _drift_rate_info(dri) {
+    }
+    
+
+    // slow-time steps passed through for a complete integration, the total number
+    // of bins contributing to this integration is demsear_bins * integration_steps
+    int64_t _integration_steps;
+
+    std::vector<drift_rate> _drift_rate_info; // info for each drift rate searched (consider changing to map with key being integer number of unit drifts)
+
+    // The actual frequency drift plane
+    bland::ndarray _integrated_drifts;
+
+    integrated_flags _dedrifted_rfi;
+
+};
+
+} // namespace bliss

--- a/bliss/drift_search/hit_search.cpp
+++ b/bliss/drift_search/hit_search.cpp
@@ -12,8 +12,8 @@ using namespace bliss;
 
 float bliss::compute_signal_threshold(const noise_stats &noise_stats, int64_t integration_length, float snr_threshold) {
     // When the signal amplitude is snr_threshold above the noise floor, we have a 'prehit' (a signal that naively
-    // passes a hard threshold) that is when S/N > snr_threshold Given a noise floor estimate of nf, signal power above threshold S,
-    // noise power N...
+    // passes a hard threshold) that is when S/N > snr_threshold Given a noise floor estimate of nf, signal power above
+    // threshold S, noise power N...
     // (S - noise_floor) / N > snr_threshold
     // S - noise_floor > N * snr_threshold
     // S > noise_floor + N * snr_threshold
@@ -21,6 +21,27 @@ float bliss::compute_signal_threshold(const noise_stats &noise_stats, int64_t in
     float integration_adjusted_noise_power = noise_stats.noise_power() / std::sqrt(integration_length);
     auto  threshold = noise_stats.noise_floor() + integration_adjusted_noise_power * snr_threshold;
     return threshold;
+}
+
+std::vector<std::pair<float, float>> bliss::compute_noise_and_snr_thresholds(const noise_stats &noise_stats,
+                                            int64_t            integration_length,
+                                            std::vector<frequency_drift_plane::drift_rate> drift_rates,
+                                            float snr_threshold) {
+    // When the signal amplitude is snr_threshold above the noise floor, we have a 'prehit' (a signal that naively
+    // passes a hard threshold) that is when S/N > snr_threshold Given a noise floor estimate of nf, signal power above
+    // threshold S, noise power N...
+    // (S - noise_floor) / N > snr_threshold
+    // S - noise_floor > N * snr_threshold
+    // S > noise_floor + N * snr_threshold
+    // We have incoherently integrated (with mean) l bins, so adjust the noise power by sqrt(l)
+    std::vector<std::pair<float, float>> thresholds;
+    for (auto &drift : drift_rates) {
+        float integration_adjusted_noise_power = noise_stats.noise_power() / std::sqrt(integration_length * drift.desmeared_bins);
+        auto  threshold = noise_stats.noise_floor() + integration_adjusted_noise_power * snr_threshold;
+        thresholds.push_back({threshold, integration_adjusted_noise_power});
+    }
+
+    return thresholds;
 }
 
 bland::ndarray bliss::hard_threshold_drifts(const bland::ndarray &dedrifted_spectrum,
@@ -44,10 +65,9 @@ std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_optio
     } else if (options.method == hit_search_methods::LOCAL_MAXIMA) {
         components = find_local_maxima_above_threshold(dedrifted_scan, options.snr_threshold, options.neighborhood);
     }
-    auto noise_stats = dedrifted_scan.noise_estimate();
-    auto dedrifted_plane = dedrifted_scan.integrated_drift_plane();
+    auto noise_stats        = dedrifted_scan.noise_estimate();
+    auto dedrifted_plane    = dedrifted_scan.integrated_drift_plane();
     auto integration_length = dedrifted_plane._integration_steps;
-
 
     // Do we need a "component to hit" for each type of search?
     for (const auto &c : components) {
@@ -61,21 +81,16 @@ std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_optio
         auto freq_offset        = dedrifted_scan.foff() * this_hit.start_freq_index;
         this_hit.start_freq_MHz = dedrifted_scan.fch1() + freq_offset;
 
-        // auto drift_freq_span_bins = dedrifted_scan.dedoppler_options().low_rate +
-        //                             this_hit.rate_index * dedrifted_scan.dedoppler_options().rate_step_size;
-        // float drift_span_freq_Hz = drift_freq_span_bins * 1e6 * dedrifted_scan.foff();
-        this_hit.drift_rate_Hz_per_sec =  dedrifted_plane._drift_rate_info[this_hit.rate_index].drift_rate_slope * dedrifted_scan.foff()*1e6 / dedrifted_scan.tsamp();
-
-
-        // auto drift_span_time_bins = integration_length;
-        // auto drift_span_time_sec  = drift_span_time_bins * dedrifted_scan.tsamp();
-
-        // this_hit.drift_rate_Hz_per_sec = drift_span_freq_Hz / drift_span_time_sec;
+        this_hit.drift_rate_Hz_per_sec = dedrifted_plane._drift_rate_info[this_hit.rate_index].drift_rate_slope *
+                                         dedrifted_scan.foff() * 1e6 / dedrifted_scan.tsamp();
 
         auto signal_power = (c.max_integration - noise_stats.noise_floor());
-        auto noise_power  = (noise_stats.noise_power() / std::sqrt(integration_length));
-        this_hit.power    = signal_power;
-        this_hit.snr      = signal_power / noise_power;
+
+        // This is the unsmeared SNR
+        // auto noise_power  = (noise_stats.noise_power() / std::sqrt(integration_length));
+        // this_hit.power    = signal_power;
+        // this_hit.snr      = signal_power / noise_power;
+        this_hit.snr      = signal_power / c.desmeared_noise;
 
         // At the drift rate with max SNR, find the width of this component
         // We can also integrate signal power over the entire bandwidth / noise power over bandwidth to get
@@ -113,7 +128,7 @@ std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_optio
 scan bliss::hit_search(scan dedrifted_scan, hit_search_options options) {
     auto number_coarse_channels = dedrifted_scan.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc = dedrifted_scan.get_coarse_channel(cc_index);
+        auto cc   = dedrifted_scan.get_coarse_channel(cc_index);
         auto hits = hit_search(*cc, options);
         cc->add_hits(hits);
     }

--- a/bliss/drift_search/hit_search.cpp
+++ b/bliss/drift_search/hit_search.cpp
@@ -64,7 +64,7 @@ std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_optio
         // auto drift_freq_span_bins = dedrifted_scan.dedoppler_options().low_rate +
         //                             this_hit.rate_index * dedrifted_scan.dedoppler_options().rate_step_size;
         // float drift_span_freq_Hz = drift_freq_span_bins * 1e6 * dedrifted_scan.foff();
-        this_hit.drift_rate_Hz_per_sec =  dedrifted_plane._drift_rate_info[this_hit.rate_index].drift_rate_slope * dedrifted_scan.foff() / dedrifted_scan.tsamp();
+        this_hit.drift_rate_Hz_per_sec =  dedrifted_plane._drift_rate_info[this_hit.rate_index].drift_rate_slope * dedrifted_scan.foff()*1e6 / dedrifted_scan.tsamp();
 
 
         // auto drift_span_time_bins = integration_length;

--- a/bliss/drift_search/include/drift_search/connected_components.hpp
+++ b/bliss/drift_search/include/drift_search/connected_components.hpp
@@ -21,6 +21,6 @@ std::vector<component> find_components_in_binary_mask(const bland::ndarray &thre
  * Given noise stats do a combined threshold and cluster of nearby components
  */
 std::vector<component>
-find_components_above_threshold(coarse_channel &dedrifted_spectrum, float snr_threshold, std::vector<nd_coords> neighborhood);
+find_components_above_threshold(coarse_channel &dedrifted_coarse_channel, float snr_threshold, std::vector<nd_coords> neighborhood);
 
 } // namespace bliss

--- a/bliss/drift_search/include/drift_search/hit_search.hpp
+++ b/bliss/drift_search/include/drift_search/hit_search.hpp
@@ -16,6 +16,8 @@ using rfi       = std::map<flag_values, uint8_t>; // TODO: not so elegant, but O
 struct component {
     std::vector<nd_coords> locations;
     float                  max_integration = std::numeric_limits<float>::lowest();
+    // float                  max_snr; // it might be more general to save off the noise est. of this component
+    float                  desmeared_noise;
     rfi                    rfi_counts;
     nd_coords              index_max;
 };
@@ -30,6 +32,11 @@ struct component {
   * We have incoherently integrated (with mean) l bins, so adjust the noise power by sqrt(l)
  */
 float compute_signal_threshold(const noise_stats &noise_stats, int64_t integration_length, float snr_threshold);
+
+std::vector<std::pair<float, float>> compute_noise_and_snr_thresholds(const noise_stats   &noise_stats,
+                                            int64_t                                        integration_length,
+                                            std::vector<frequency_drift_plane::drift_rate> drift_rates,
+                                            float                                          snr_threshold);
 
 /**
  * Return a binary mask (dtype uint8) when doppler spectrum values fall above

--- a/bliss/drift_search/include/drift_search/integrate_drifts.hpp
+++ b/bliss/drift_search/include/drift_search/integrate_drifts.hpp
@@ -7,18 +7,6 @@
 
 namespace bliss {
 
-struct frequency_drift_plane {
-        struct drift_rates {
-                int index_in_plane;
-                double drift_rate_Hz_per_sec=0.0F;
-                int desmeared_bins=1; // number of bins per spectra used to desmear
-        };
-
-        int64_t integration_steps; // slow-time steps passed through for a complete integration
-        std::vector<drift_rates> drift_rate_info; // info for each drift rate searched
-        bland::ndarray integrated_drifts;
-        // TODO: rfi info should belong here
-};
 
 /**
  * Methods to select bins along a linear track in time-frequency spectrum estimate.

--- a/bliss/drift_search/include/drift_search/integrate_drifts.hpp
+++ b/bliss/drift_search/include/drift_search/integrate_drifts.hpp
@@ -59,7 +59,7 @@ integrate_drifts(coarse_channel cc_data, integrate_drifts_options options = inte
 /**
  * Integrate energy through linear tracks in the scans of given observation target
  *
- * The returned observation_target is a copy of the given observation_target with valid dedrifted_spectrum
+ * The returned observation_target is a copy of the given observation_target with valid dedrifted_coarse_channel
  * fields of each scan.
  */
 [[nodiscard]] observation_target integrate_drifts(observation_target       target,
@@ -69,7 +69,7 @@ integrate_drifts(coarse_channel cc_data, integrate_drifts_options options = inte
 /**
  * Integrate energy through linear tracks in the scans of the given cadence
  *
- * The returned cadence is a copy of the given cadence with valid dedrifted_spectrum for each scan
+ * The returned cadence is a copy of the given cadence with valid dedrifted_coarse_channel for each scan
  * in each observation target.
  */
 [[nodiscard]] cadence integrate_drifts(cadence                  observations,

--- a/bliss/drift_search/include/drift_search/local_maxima.hpp
+++ b/bliss/drift_search/include/drift_search/local_maxima.hpp
@@ -4,7 +4,7 @@
 
 namespace bliss {
 
-std::vector<component> find_local_maxima_above_threshold(coarse_channel        &dedrifted_spectrum,
+std::vector<component> find_local_maxima_above_threshold(coarse_channel        &dedrifted_coarse_channel,
                                                          float                  snr_threshold,
                                                          std::vector<nd_coords> max_neighborhoods);
 

--- a/bliss/drift_search/include/drift_search/pydrift_search.hpp
+++ b/bliss/drift_search/include/drift_search/pydrift_search.hpp
@@ -59,12 +59,12 @@ void bind_pydrift_search(nb::module_ m) {
     // Generic thresholding methods
     m.def("hard_threshold_drifts", &bliss::hard_threshold_drifts);
     m.def("hard_threshold_drifts",
-          [](const nb::ndarray<>      &dedrifted_spectrum,
+          [](const nb::ndarray<>      &dedrifted_coarse_channel,
              const bliss::noise_stats &noise_stats,
              int64_t                   integration_length,
              float                     snr_threshold) {
               return bliss::hard_threshold_drifts(
-                      nb_to_bland(dedrifted_spectrum), noise_stats, integration_length, snr_threshold);
+                      nb_to_bland(dedrifted_coarse_channel), noise_stats, integration_length, snr_threshold);
           });
 
     nb::class_<bliss::filter_options>(m, "filter_options")

--- a/bliss/drift_search/kernels/drift_integration_bland.cpp
+++ b/bliss/drift_search/kernels/drift_integration_bland.cpp
@@ -1,6 +1,8 @@
 
 #include "drift_integration_bland.hpp"
 
+#include "core/frequency_drift_plane.hpp"
+
 #include <bland/ops.hpp>
 
 #include <fmt/format.h>
@@ -23,11 +25,12 @@ using namespace bliss;
 
 constexpr bool collect_rfi = true;
 // template <bool collect_rfi>
-[[nodiscard]] std::tuple<bland::ndarray, integrated_flags>
-bliss::integrate_linear_rounded_bins(const bland::ndarray    &spectrum_grid,
+[[nodiscard]] frequency_drift_plane
+bliss::integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_grid,
                                      const bland::ndarray    &rfi_mask,
                                      integrate_drifts_options options) {
     auto number_drifts = (options.high_rate - options.low_rate) / options.rate_step_size;
+    std::vector<frequency_drift_plane::drift_rate> drift_rate_info;
 
     auto time_steps      = spectrum_grid.size(0);
     auto number_channels = spectrum_grid.size(1);
@@ -45,15 +48,19 @@ bliss::integrate_linear_rounded_bins(const bland::ndarray    &spectrum_grid,
     for (int drift_index = 0; drift_index < number_drifts; ++drift_index) {
         // Drift in number of channels over the entire time extent
         auto drift_channels = options.low_rate + drift_index * options.rate_step_size;
+        frequency_drift_plane::drift_rate rate;
+        rate.index_in_plane = drift_index;
 
         // The actual slope of that drift (number channels / time)
         auto m = static_cast<float>(drift_channels) / static_cast<float>(maximum_drift_span);
+        rate.drift_rate_slope = m;
         // If a single time step crosses more than 1 channel, there is smearing over multiple channels
         auto smeared_channels = std::round(std::abs(m));
 
         int desmear_bandwidth = 1;
         if (options.desmear) {
             desmear_bandwidth = std::max(1.0f, smeared_channels);
+            rate.desmeared_bins = smeared_channels;
         }
 
         for (int t = 0; t < time_steps; ++t) {
@@ -219,12 +226,13 @@ bliss::integrate_linear_rounded_bins(const bland::ndarray    &spectrum_grid,
     }
 
     // normalize back by integration length
-    return std::make_tuple(drift_plane / time_steps, rfi_in_drift);
+    frequency_drift_plane freq_drift(drift_plane / time_steps, rfi_in_drift, time_steps, drift_rate_info);
+    return freq_drift;
 }
 
-bland::ndarray bliss::integrate_linear_rounded_bins(const bland::ndarray    &spectrum_grid,
+bland::ndarray bliss::integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_grid,
                                                     integrate_drifts_options options) {
     auto dummy_rfi_mask                      = bland::ndarray({1, 1});
-    auto [drift_plane, dummy_rfi_collection] = integrate_linear_rounded_bins(spectrum_grid, dummy_rfi_mask, options);
-    return drift_plane;
+    auto drift_plane = integrate_linear_rounded_bins_bland(spectrum_grid, dummy_rfi_mask, options);
+    return drift_plane._integrated_drifts;
 }

--- a/bliss/drift_search/kernels/drift_integration_bland.cpp
+++ b/bliss/drift_search/kernels/drift_integration_bland.cpp
@@ -62,6 +62,7 @@ bliss::integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_gri
             desmear_bandwidth = std::max(1.0f, smeared_channels);
             rate.desmeared_bins = smeared_channels;
         }
+        drift_rate_info.push_back(rate);
 
         for (int t = 0; t < time_steps; ++t) {
             int freq_offset_at_time = std::round(m * t);

--- a/bliss/drift_search/kernels/drift_integration_bland.hpp
+++ b/bliss/drift_search/kernels/drift_integration_bland.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <core/integrate_drifts_options.hpp>
+#include <core/frequency_drift_plane.hpp>
 
 #include <bland/ndarray.hpp>
 
@@ -20,11 +21,11 @@ namespace bliss {
  * drifts will have frequency spans of 0, 1, 2, 3, 4, 5, 6, 7 giving 8 slopes of
  * value 0/7, 1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7.
  */
-[[nodiscard]] std::tuple<bland::ndarray, integrated_flags>
-integrate_linear_rounded_bins(const bland::ndarray    &spectrum_grid,
+[[nodiscard]] frequency_drift_plane
+integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_grid,
                               const bland::ndarray    &rfi_mask,
                               integrate_drifts_options options);
 
-bland::ndarray integrate_linear_rounded_bins(const bland::ndarray &spectrum_grid, integrate_drifts_options options);
+bland::ndarray integrate_linear_rounded_bins_bland(const bland::ndarray &spectrum_grid, integrate_drifts_options options);
 
 } // namespace bliss

--- a/bliss/drift_search/kernels/drift_integration_cpu.cpp
+++ b/bliss/drift_search/kernels/drift_integration_cpu.cpp
@@ -65,6 +65,7 @@ bliss::integrate_linear_rounded_bins_cpu(const bland::ndarray    &spectrum_grid,
             desmear_bandwidth = std::max(1.0f, smeared_channels);
             rate.desmeared_bins = smeared_channels;
         }
+        drift_rate_info.push_back(rate);
 
         for (int t = 0; t < time_steps; ++t) {
             int freq_offset_at_time  = std::round(m * t);

--- a/bliss/drift_search/kernels/drift_integration_cpu.cpp
+++ b/bliss/drift_search/kernels/drift_integration_cpu.cpp
@@ -1,6 +1,8 @@
 
 #include "drift_integration_cpu.hpp"
 
+#include "core/frequency_drift_plane.hpp"
+
 #include <fmt/core.h>
 #include <fmt/format.h>
 
@@ -8,7 +10,7 @@
 
 using namespace bliss;
 
-[[nodiscard]] std::tuple<bland::ndarray, integrated_flags>
+[[nodiscard]] frequency_drift_plane
 bliss::integrate_linear_rounded_bins_cpu(const bland::ndarray    &spectrum_grid,
                                          const bland::ndarray    &rfi_mask,
                                          integrate_drifts_options options) {
@@ -21,6 +23,7 @@ bliss::integrate_linear_rounded_bins_cpu(const bland::ndarray    &spectrum_grid,
     auto rfi_shape   = rfi_mask.shape();
 
     auto number_drifts = (options.high_rate - options.low_rate) / options.rate_step_size;
+    std::vector<frequency_drift_plane::drift_rate> drift_rate_info;
 
     auto time_steps      = spectrum_grid.size(0);
     auto number_channels = spectrum_grid.size(1);
@@ -48,15 +51,19 @@ bliss::integrate_linear_rounded_bins_cpu(const bland::ndarray    &spectrum_grid,
     for (int drift_index = 0; drift_index < number_drifts; ++drift_index) {
         // Drift in number of channels over the entire time extent
         auto drift_channels = options.low_rate + drift_index * options.rate_step_size;
+        frequency_drift_plane::drift_rate rate;
+        rate.index_in_plane = drift_index;
 
         // The actual slope of that drift (number channels / time)
         auto m = static_cast<float>(drift_channels) / static_cast<float>(maximum_drift_span);
+        rate.drift_rate_slope = m;
         // If a single time step crosses more than 1 channel, there is smearing over multiple channels
         auto smeared_channels = std::round(std::abs(m));
 
         int desmear_bandwidth = 1;
         if (options.desmear) {
             desmear_bandwidth = std::max(1.0f, smeared_channels);
+            rate.desmeared_bins = smeared_channels;
         }
 
         for (int t = 0; t < time_steps; ++t) {
@@ -166,13 +173,13 @@ bliss::integrate_linear_rounded_bins_cpu(const bland::ndarray    &spectrum_grid,
     }
 
     // normalize back by integration length
-    return std::make_tuple(drift_plane / time_steps, rfi_in_drift);
+    frequency_drift_plane freq_drift(drift_plane / time_steps, rfi_in_drift, time_steps, drift_rate_info);
+    return freq_drift;
 }
 
 bland::ndarray bliss::integrate_linear_rounded_bins_cpu(const bland::ndarray    &spectrum_grid,
                                                         integrate_drifts_options options) {
     auto dummy_rfi_mask = bland::ndarray({1, 1});
-    auto [drift_plane, dummy_rfi_collection] =
-            integrate_linear_rounded_bins_cpu(spectrum_grid, dummy_rfi_mask, options);
-    return drift_plane;
+    auto drift_plane = integrate_linear_rounded_bins_cpu(spectrum_grid, dummy_rfi_mask, options);
+    return drift_plane._integrated_drifts;
 }

--- a/bliss/drift_search/kernels/drift_integration_cpu.hpp
+++ b/bliss/drift_search/kernels/drift_integration_cpu.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <core/integrate_drifts_options.hpp>
+#include <core/frequency_drift_plane.hpp>
 
 #include <bland/ndarray.hpp>
 
@@ -12,7 +13,7 @@ namespace bliss {
  * linear-rounded integration kernel implemented for cpu
 */
 constexpr bool collect_rfi = true;
-[[nodiscard]] std::tuple<bland::ndarray, integrated_flags>
+[[nodiscard]] frequency_drift_plane
 integrate_linear_rounded_bins_cpu(const bland::ndarray    &spectrum_grid,
                                   const bland::ndarray    &rfi_mask,
                                   integrate_drifts_options options);

--- a/bliss/justrun.cpp
+++ b/bliss/justrun.cpp
@@ -26,23 +26,24 @@ int main(int argc, char **argv) {
     //     fil_path = argv[1];
     // }
 
-    auto mlc4_cadence = bliss::cadence({{"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_08789_HIP54677_0009.gpuspec.0000.h5",
-                     "/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_09628_HIP54677_0011.gpuspec.0000.h5",
-                     "/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10436_HIP54677_0013.gpuspec.0000.h5"},
-                     {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_09209_HIP53759_0010.gpuspec.0000.h5"},
-                     {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10032_HIP53820_0012.gpuspec.0000.h5"},
-                     {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10836_HIP53839_0014.gpuspec.0000.h5"}});
+    // auto mlc4_cadence = bliss::cadence({{"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_08789_HIP54677_0009.gpuspec.0000.h5",
+    //                  "/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_09628_HIP54677_0011.gpuspec.0000.h5",
+    //                  "/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10436_HIP54677_0013.gpuspec.0000.h5"},
+    //                  {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_09209_HIP53759_0010.gpuspec.0000.h5"},
+    //                  {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10032_HIP53820_0012.gpuspec.0000.h5"},
+    //                  {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10836_HIP53839_0014.gpuspec.0000.h5"}});
 
 
-    // auto cadence = bliss::cadence({{"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5",
-    //                 "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80672_DIAG_VOYAGER-1_0013.rawspec.0000.h5",
-    //                 "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81310_DIAG_VOYAGER-1_0015.rawspec.0000.h5"
-    //                 },
-    //                 {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"},
-    //                 {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80989_DIAG_VOYAGER-1_0014.rawspec.0000.h5"},
-    //                 {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81628_DIAG_VOYAGER-1_0016.rawspec.0000.h5"}});
+    auto voyager_cadence = bliss::cadence({{"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5",
+                    "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80672_DIAG_VOYAGER-1_0013.rawspec.0000.h5",
+                    "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81310_DIAG_VOYAGER-1_0015.rawspec.0000.h5"
+                    },
+                    {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"},
+                    {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80989_DIAG_VOYAGER-1_0014.rawspec.0000.h5"},
+                    {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81628_DIAG_VOYAGER-1_0016.rawspec.0000.h5"}});
 
-    auto cadence = mlc4_cadence.slice_cadence_channels(188);
+    // auto cadence = voyager_cadence.slice_cadence_channels(188);
+    auto cadence = voyager_cadence;
 
     cadence = bliss::flag_filter_rolloff(cadence, 0.2);
     cadence = bliss::flag_spectral_kurtosis(cadence, 0.02, 25);

--- a/bliss/justrun.cpp
+++ b/bliss/justrun.cpp
@@ -21,23 +21,28 @@
 
 int main(int argc, char **argv) {
 
-    std::string fil_path{"/home/nathan/datasets/voyager_2020_data/"
-                         "single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"};
-    if (argc == 2) {
-        fil_path = argv[1];
-    }
 
-    // bliss::cadence({{"/home/nathan/datasets/voyager_2020_data/"
-    //                      "single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"}});
+    // if (argc == 2) {
+    //     fil_path = argv[1];
+    // }
 
-    auto cadence = bliss::cadence({{"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5",
-                    "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80672_DIAG_VOYAGER-1_0013.rawspec.0000.h5",
-                    "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81310_DIAG_VOYAGER-1_0015.rawspec.0000.h5"
-                    },
-                    {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"},
-                    {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80989_DIAG_VOYAGER-1_0014.rawspec.0000.h5"},
-                    {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81628_DIAG_VOYAGER-1_0016.rawspec.0000.h5"}});
+    auto mlc4_cadence = bliss::cadence({{"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_08789_HIP54677_0009.gpuspec.0000.h5",
+                     "/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_09628_HIP54677_0011.gpuspec.0000.h5",
+                     "/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10436_HIP54677_0013.gpuspec.0000.h5"},
+                     {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_09209_HIP53759_0010.gpuspec.0000.h5"},
+                     {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10032_HIP53820_0012.gpuspec.0000.h5"},
+                     {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10836_HIP53839_0014.gpuspec.0000.h5"}});
 
+
+    // auto cadence = bliss::cadence({{"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5",
+    //                 "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80672_DIAG_VOYAGER-1_0013.rawspec.0000.h5",
+    //                 "/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81310_DIAG_VOYAGER-1_0015.rawspec.0000.h5"
+    //                 },
+    //                 {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"},
+    //                 {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80989_DIAG_VOYAGER-1_0014.rawspec.0000.h5"},
+    //                 {"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_81628_DIAG_VOYAGER-1_0016.rawspec.0000.h5"}});
+
+    auto cadence = mlc4_cadence.slice_cadence_channels(188);
 
     cadence = bliss::flag_filter_rolloff(cadence, 0.2);
     cadence = bliss::flag_spectral_kurtosis(cadence, 0.02, 25);
@@ -46,21 +51,21 @@ int main(int argc, char **argv) {
             cadence,
             bliss::noise_power_estimate_options{.estimator_method=bliss::noise_power_estimator::STDDEV, .masked_estimate = true}); // estimate noise power of unflagged data
 
-    // cadence = bliss::integrate_drifts(
-    //         cadence,
-    //         bliss::integrate_drifts_options{.desmear        = false,
-    //                                         .low_rate       = -48,
-    //                                         .high_rate      = 48,
-    //                                         .rate_step_size = 1});
+    cadence = bliss::integrate_drifts(
+            cadence,
+            bliss::integrate_drifts_options{.desmear        = false,
+                                            .low_rate       = -48,
+                                            .high_rate      = 48,
+                                            .rate_step_size = 1});
 
-    // cadence = bliss::hit_search(cadence, {.method=bliss::hit_search_methods::CONNECTED_COMPONENTS, .snr_threshold=10.0f});
+    cadence = bliss::hit_search(cadence, {.method=bliss::hit_search_methods::CONNECTED_COMPONENTS, .snr_threshold=10.0f});
 
-    // bliss::write_cadence_hits_to_files(cadence, "hits");
+    bliss::write_cadence_hits_to_files(cadence, "hits");
 
-    // auto events = bliss::event_search(cadence);
+    auto events = bliss::event_search(cadence);
 
-    // // cadence = bliss::filter_hits(cadence, {});
+    // cadence = bliss::filter_hits(cadence, {});
 
-    // bliss::write_events_to_file(events, "events_output");
+    bliss::write_events_to_file(events, "events_output");
 
 }


### PR DESCRIPTION
Added a class to capture all of the information around frequency drift plane including info on desmeared integrations and some improved book-keeping for drift rates. (closes #4)

Then used that info to correct the noise estimates used for SNR estimates / thresholds for desmeared integrations. (closes #5)

The result @ SNR=10 picks up 11 events from the voyager-1 capture all above an SNR of 10. These all appear valid as

* carrier (1 events)
* left and right data carrier main lobes (2 events)
* left and right sidelobe for each of those (4 events)
* probably harmonics of an IF where the baud-rate peaks of modulation are still barely visible (4 events)

![image](https://github.com/n-west/bliss/assets/1879306/6b3943e0-f45e-4bf1-a438-15616cc84768)

![image](https://github.com/n-west/bliss/assets/1879306/3e72a4e8-ff11-4901-a8c0-23c1363fe67c)

![image](https://github.com/n-west/bliss/assets/1879306/ce86c7ce-c813-491f-833f-f845e5224552)

![image](https://github.com/n-west/bliss/assets/1879306/ded1434f-c0e8-45b2-a0ae-36a720577680)
