### PR TITLE
cuda pipeline through integration

### DIFF
--- a/bland/CMakeLists.txt
+++ b/bland/CMakeLists.txt
@@ -19,7 +19,7 @@ add_feature_info(CUDA WITH_CUDA "Using CUDA as a backend for array storage and c
 if (WITH_CUDA)
   message("BLAND:: enabling cuda (the language)")
   if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES native)
+    set(CMAKE_CUDA_ARCHITECTURES all-major)
   endif()
   enable_language(CUDA)
   add_definitions("-DBLAND_CUDA_CODE=1")

--- a/bland/bland/bland_tensor_internals.cpp
+++ b/bland/bland/bland_tensor_internals.cpp
@@ -88,7 +88,6 @@ blandDLTensor::blandDLTensor(const std::vector<int64_t> &shape,
         }
         _data_ownership = std::shared_ptr<void>(ptr, free);
     } else if (DLTensor::device.device_type == DLDeviceType::kDLCUDA) {
-        /* todo */
         #if BLAND_CUDA
         void* ptr = nullptr;
         cudaSetDevice(device.device_id);

--- a/bland/bland/include/bland/ops_comparison.hpp
+++ b/bland/bland/include/bland/ops_comparison.hpp
@@ -65,11 +65,5 @@ operator==(L lhs, R rhs);
 // float absolute_tolerance); template <typename T> std::enable_if_t<std::is_arithmetic<T>::value, ndarray>
 // approx_equal(T lhs, ndarray rhs, float relative_tolerance, float absolute_tolerance);
 
-/**
- * return the number of elements that will evaluate to true
- *
- * TODO: optionally add an dim parameter
- */
-int64_t count_true(ndarray x);
 
 } // namespace bland

--- a/bland/bland/include/bland/ops_statistical.hpp
+++ b/bland/bland/include/bland/ops_statistical.hpp
@@ -41,4 +41,13 @@ float median(const ndarray &a, std::vector<int64_t> axes={});
 // ndarray median(const ndarray &a, std::vector<int64_t> axes={});
 // ndarray median(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 
+
+/**
+ * return the number of elements that will evaluate to true
+ *
+ * TODO: optionally add an dim parameter
+ */
+int64_t count_true(ndarray x);
+
+
 } // namespace bland

--- a/bland/bland/ndarray.cpp
+++ b/bland/bland/ndarray.cpp
@@ -145,63 +145,64 @@ bland::ndarray::ndarray(std::vector<int64_t> dims, T initial_value, datatype dty
         stride *= _tensor.shape[j];               // Update stride for the next dimension
     }
 
-    switch (dtype.code) {
-    case kDLFloat: {
-        switch (dtype.bits) {
-        case 32:
-            initialize_memory(data_ptr<float>(), numel(), static_cast<float>(initial_value));
-            break;
-        case 64:
-            initialize_memory(data_ptr<double>(), numel(), static_cast<double>(initial_value));
-            break;
-        default:
-            throw std::runtime_error("Unsupported float bitwidth");
-        }
-        break;
-    }
-    case kDLInt: {
-        switch (dtype.bits) {
-        case 8:
-            initialize_memory(data_ptr<int8_t>(), numel(), static_cast<int8_t>(initial_value));
-            break;
-        case 16:
-            initialize_memory(data_ptr<int16_t>(), numel(), static_cast<int16_t>(initial_value));
-            break;
-        case 32:
-            initialize_memory(data_ptr<int32_t>(), numel(), static_cast<int32_t>(initial_value));
-            break;
-        case 64:
-            initialize_memory(data_ptr<int64_t>(), numel(), static_cast<int64_t>(initial_value));
-            break;
-        default:
-            throw std::runtime_error("Unsupported int bitwidth");
-        }
-        break;
-    }
-    case kDLUInt: {
-        switch (dtype.bits) {
-        case 8:
-            initialize_memory(data_ptr<uint8_t>(), numel(), static_cast<uint8_t>(initial_value));
-            break;
-        case 16:
-            initialize_memory(data_ptr<uint16_t>(), numel(), static_cast<uint16_t>(initial_value));
-            break;
-        case 32:
-            initialize_memory(data_ptr<uint32_t>(), numel(), static_cast<uint32_t>(initial_value));
-            break;
-        case 64:
-            initialize_memory(data_ptr<uint64_t>(), numel(), static_cast<uint64_t>(initial_value));
-            break;
-        default:
-            throw std::runtime_error("Unsupported uint bitwidth");
-        }
-        break;
-    }
-    default:
-        auto error_message =
-                fmt::format("ndarray (ctor): unsupported datatype code {} with {} bits", dtype.code, dtype.bits);
-        throw std::runtime_error(error_message);
-    }
+    fill(*this, initial_value);
+    // switch (dtype.code) {
+    // case kDLFloat: {
+    //     switch (dtype.bits) {
+    //     case 32:
+    //         initialize_memory(data_ptr<float>(), numel(), static_cast<float>(initial_value));
+    //         break;
+    //     case 64:
+    //         initialize_memory(data_ptr<double>(), numel(), static_cast<double>(initial_value));
+    //         break;
+    //     default:
+    //         throw std::runtime_error("Unsupported float bitwidth");
+    //     }
+    //     break;
+    // }
+    // case kDLInt: {
+    //     switch (dtype.bits) {
+    //     case 8:
+    //         initialize_memory(data_ptr<int8_t>(), numel(), static_cast<int8_t>(initial_value));
+    //         break;
+    //     case 16:
+    //         initialize_memory(data_ptr<int16_t>(), numel(), static_cast<int16_t>(initial_value));
+    //         break;
+    //     case 32:
+    //         initialize_memory(data_ptr<int32_t>(), numel(), static_cast<int32_t>(initial_value));
+    //         break;
+    //     case 64:
+    //         initialize_memory(data_ptr<int64_t>(), numel(), static_cast<int64_t>(initial_value));
+    //         break;
+    //     default:
+    //         throw std::runtime_error("Unsupported int bitwidth");
+    //     }
+    //     break;
+    // }
+    // case kDLUInt: {
+    //     switch (dtype.bits) {
+    //     case 8:
+    //         initialize_memory(data_ptr<uint8_t>(), numel(), static_cast<uint8_t>(initial_value));
+    //         break;
+    //     case 16:
+    //         initialize_memory(data_ptr<uint16_t>(), numel(), static_cast<uint16_t>(initial_value));
+    //         break;
+    //     case 32:
+    //         initialize_memory(data_ptr<uint32_t>(), numel(), static_cast<uint32_t>(initial_value));
+    //         break;
+    //     case 64:
+    //         initialize_memory(data_ptr<uint64_t>(), numel(), static_cast<uint64_t>(initial_value));
+    //         break;
+    //     default:
+    //         throw std::runtime_error("Unsupported uint bitwidth");
+    //     }
+    //     break;
+    // }
+    // default:
+    //     auto error_message =
+    //             fmt::format("ndarray (ctor): unsupported datatype code {} with {} bits", dtype.code, dtype.bits);
+    //     throw std::runtime_error(error_message);
+    // }
 }
 
 template bland::ndarray::ndarray(std::vector<int64_t> dims, float initial_value, datatype dtype, DLDevice device);

--- a/bland/bland/ops/comparison.cpp
+++ b/bland/bland/ops/comparison.cpp
@@ -48,6 +48,10 @@ template ndarray bland::greater_than<int16_t>(int16_t lhs, ndarray rhs);
 template ndarray bland::greater_than<int32_t>(int32_t lhs, ndarray rhs);
 template ndarray bland::greater_than<int64_t>(int64_t lhs, ndarray rhs);
 
+template ndarray bland::greater_than<uint8_t, ndarray_slice>(uint8_t lhs, ndarray_slice rhs);
+template ndarray bland::greater_than<ndarray_slice, uint8_t>(ndarray_slice lhs, uint8_t rhs);
+
+
 template <typename L, typename R>
 std::enable_if_t<std::is_base_of<ndarray, std::decay_t<L>>::value || std::is_base_of<ndarray, std::decay_t<R>>::value, ndarray>
 bland::operator>(L lhs, R rhs) {
@@ -84,11 +88,11 @@ template ndarray bland::operator><int64_t, ndarray>(int64_t lhs, ndarray rhs);
 template <typename L, typename R>
 ndarray bland::greater_than_equal_to(L lhs, R rhs) {
     return device_dispatch(cpu::greater_than_equal_to<L, R>,
-                            // #if BLAND_CUDA_CODE
-                            // cuda::greater_than<L, R>,
-                            // #else
+                            #if BLAND_CUDA_CODE
+                            cuda::greater_than_equal_to<L, R>,
+                            #else
                             nullptr,
-                            // #endif
+                            #endif
                             lhs, rhs);
 }
 
@@ -153,11 +157,11 @@ template ndarray bland::operator>=<int64_t, ndarray>(int64_t lhs, ndarray rhs);
 template <typename L, typename R>
 ndarray bland::less_than(L lhs, R rhs) {
     return device_dispatch(cpu::less_than<L, R>,
-                            // #if BLAND_CUDA_CODE
-                            // cuda::greater_than<L, R>,
-                            // #else
+                            #if BLAND_CUDA_CODE
+                            cuda::less_than<L, R>,
+                            #else
                             nullptr,
-                            // #endif
+                            #endif
                             lhs, rhs);
 }
 
@@ -222,11 +226,11 @@ template ndarray bland::operator< <int64_t, ndarray>(int64_t lhs, ndarray rhs);
 template <typename L, typename R>
 ndarray bland::less_than_equal_to(L lhs, R rhs) {
     return device_dispatch(cpu::less_than_equal_to<L, R>,
-                            // #if BLAND_CUDA_CODE
-                            // cuda::greater_than<L, R>,
-                            // #else
+                            #if BLAND_CUDA_CODE
+                            cuda::less_than_equal_to<L, R>,
+                            #else
                             nullptr,
-                            // #endif
+                            #endif
                             lhs, rhs);
 }
 
@@ -291,11 +295,11 @@ template ndarray bland::operator<=<int64_t, ndarray>(int64_t lhs, ndarray rhs);
 template <typename L, typename R>
 ndarray bland::logical_and(L lhs, R rhs) {
     return device_dispatch(cpu::logical_and<L, R>,
-                            // #if BLAND_CUDA_CODE
-                            // cuda::greater_than<L, R>,
-                            // #else
+                            #if BLAND_CUDA_CODE
+                            cuda::logical_and<L, R>,
+                            #else
                             nullptr,
-                            // #endif
+                            #endif
                             lhs, rhs);
 }
 
@@ -322,6 +326,10 @@ template ndarray bland::logical_and<int8_t>(int8_t lhs, ndarray rhs);
 template ndarray bland::logical_and<int16_t>(int16_t lhs, ndarray rhs);
 template ndarray bland::logical_and<int32_t>(int32_t lhs, ndarray rhs);
 template ndarray bland::logical_and<int64_t>(int64_t lhs, ndarray rhs);
+
+template ndarray bland::logical_and<uint8_t, ndarray_slice>(uint8_t lhs, ndarray_slice rhs);
+template ndarray bland::logical_and<ndarray_slice, uint8_t>(ndarray_slice lhs, uint8_t rhs);
+
 
 template <typename L, typename R>
 std::enable_if_t<std::is_base_of<ndarray, std::decay_t<L>>::value || std::is_base_of<ndarray, std::decay_t<R>>::value, ndarray>
@@ -353,6 +361,9 @@ template ndarray bland::operator&<int16_t, ndarray>(int16_t lhs, ndarray rhs);
 template ndarray bland::operator&<int32_t, ndarray>(int32_t lhs, ndarray rhs);
 template ndarray bland::operator&<int64_t, ndarray>(int64_t lhs, ndarray rhs);
 
+template ndarray bland::operator&<uint8_t, ndarray_slice>(uint8_t lhs, ndarray_slice rhs);
+template ndarray bland::operator&<ndarray_slice, uint8_t>(ndarray_slice lhs, uint8_t rhs);
+
 
 /**
  * equal_to (==)
@@ -360,11 +371,11 @@ template ndarray bland::operator&<int64_t, ndarray>(int64_t lhs, ndarray rhs);
 template <typename L, typename R>
 ndarray bland::equal_to(L lhs, R rhs) {
     return device_dispatch(cpu::equal_to<L, R>,
-                            // #if BLAND_CUDA_CODE
-                            // cuda::equal_to<L, R>,
-                            // #else
+                            #if BLAND_CUDA_CODE
+                            cuda::equal_to<L, R>,
+                            #else
                             nullptr,
-                            // #endif
+                            #endif
                             lhs, rhs);
 }
 
@@ -422,7 +433,3 @@ template ndarray bland::operator==<int16_t, ndarray>(int16_t lhs, ndarray rhs);
 template ndarray bland::operator==<int32_t, ndarray>(int32_t lhs, ndarray rhs);
 template ndarray bland::operator==<int64_t, ndarray>(int64_t lhs, ndarray rhs);
 
-
-int64_t bland::count_true(ndarray x) {
-    return cpu::count_true(x);
-}

--- a/bland/bland/ops/cpu/assignment_op.hpp
+++ b/bland/bland/ops/cpu/assignment_op.hpp
@@ -6,14 +6,10 @@
 namespace bland {
 struct ndarray;
 
+namespace cpu {
+
 /**
- * 
- * Perform an elementwise binary operation such as add, sub, mul, div as indicated
- * in the Op parameter (which will have the underlying datatypes passed through
- * as template parameters to the op) between two tensors with underlying datatypes
- * A and B.
- *
- * Currently the result datatype will be the same as A, but we should fix that!
+ * Fill out with the value of a cast to the datatype of out.
  */
 template <typename Out, typename S>
 ndarray assignment_op(ndarray &out, const S &a) {
@@ -62,4 +58,5 @@ struct assignment_op_impl_wrapper {
     }
 };
 
+} // namespace cpu
 } // namespace bland

--- a/bland/bland/ops/cpu/comparison_cpu.hpp
+++ b/bland/bland/ops/cpu/comparison_cpu.hpp
@@ -27,10 +27,5 @@ ndarray logical_and(L lhs, R rhs);
 template <typename L, typename R>
 ndarray equal_to(L lhs, R rhs);
 
-/**
- * return the number of elements that will evaluate to true
- */
-int64_t count_true(ndarray x);
-
 } // namespace cpu
 } // namespace bland

--- a/bland/bland/ops/cpu/ops_cpu.cpp
+++ b/bland/bland/ops/cpu/ops_cpu.cpp
@@ -3,6 +3,8 @@
 
 #include "arithmetic_cpu_impl.hpp"
 #include "elementwise_unary_op.hpp"
+#include "assignment_op.hpp"
+
 #include "dispatcher.hpp"
 
 #include "bland/ndarray.hpp"
@@ -27,3 +29,19 @@ ndarray bland::cpu::sqrt(ndarray a, ndarray& out) {
 ndarray bland::cpu::abs(ndarray a, ndarray& out) {
     return dispatch_new2<cpu::unary_op_impl_wrapper, elementwise_abs_op>(out, a);
 }
+
+template <typename T>
+ndarray bland::cpu::fill(ndarray out, T value) {
+    return dispatch_new<cpu::assignment_op_impl_wrapper, T>(out, value);
+}
+
+template ndarray bland::cpu::fill<float>(ndarray out, float v);
+template ndarray bland::cpu::fill<double>(ndarray out, double v);
+template ndarray bland::cpu::fill<int8_t>(ndarray out, int8_t v);
+template ndarray bland::cpu::fill<int16_t>(ndarray out, int16_t v);
+template ndarray bland::cpu::fill<int32_t>(ndarray out, int32_t v);
+template ndarray bland::cpu::fill<int64_t>(ndarray out, int64_t v);
+template ndarray bland::cpu::fill<uint8_t>(ndarray out, uint8_t v);
+template ndarray bland::cpu::fill<uint16_t>(ndarray out, uint16_t v);
+template ndarray bland::cpu::fill<uint32_t>(ndarray out, uint32_t v);
+template ndarray bland::cpu::fill<uint64_t>(ndarray out, uint64_t v);

--- a/bland/bland/ops/cpu/ops_cpu.hpp
+++ b/bland/bland/ops/cpu/ops_cpu.hpp
@@ -11,5 +11,8 @@ ndarray square(ndarray a, ndarray& out);
 ndarray sqrt(ndarray a, ndarray& out);
 ndarray abs(ndarray a, ndarray& out);
 
+template <typename T>
+ndarray fill(ndarray out, T value);
+
 } // namespace cpu
 } // namespace bland

--- a/bland/bland/ops/cpu/statistical_cpu.cpp
+++ b/bland/bland/ops/cpu/statistical_cpu.cpp
@@ -798,3 +798,50 @@ struct sum_impl {
 ndarray bland::cpu::sum(const ndarray &a, ndarray &out, std::vector<int64_t> axes) {
     return dispatch_new<sum_impl>(out, a, axes);
 }
+
+
+struct count_impl {
+    template <typename in_datatype>
+    static inline int64_t call(const ndarray &a) {
+
+        auto a_data    = a.data_ptr<in_datatype>();
+        auto a_shape   = a.shape();
+        auto a_strides = a.strides();
+        auto a_offset  = a.offsets();
+
+        std::vector<int64_t> input_index(a_shape.size(), 0);
+        int64_t a_linear_index = std::accumulate(a_offset.begin(), a_offset.end(), 0);
+
+        int64_t count = 0;
+        auto    numel = a.numel();
+        for (int i = 0; i < numel; ++i) {
+            // Make a copy of the current input index, we'll fix the non-summed dims
+            // and iterate over the reduced dims accumulating the total
+            if (a_data[a_linear_index]) {
+                ++count;
+            }
+
+            // Increment the multi-dimensional input index
+            // TODO: I think I can dedupe this with above by checking if axis is in reduce axis but that may actually be
+            // less efficient
+            for (int dim = a_shape.size() - 1; dim >= 0; --dim) {
+                // If we're not at the end of this dim, keep going
+                ++input_index[dim];
+                a_linear_index += a_strides[dim];
+                if (input_index[dim] < a_shape[dim]) {
+                    break;
+                } else {
+                    // Otherwise, set it to 0 and move down to the next dim
+                    input_index[dim] = 0;
+                    a_linear_index -= (a_shape[dim]) * a_strides[dim];
+                }
+            }
+        }
+
+        return count;
+    }
+};
+
+int64_t bland::cpu::count_true(ndarray x) {
+    return dispatch_summary<count_impl>(x);
+}

--- a/bland/bland/ops/cpu/statistical_cpu.hpp
+++ b/bland/bland/ops/cpu/statistical_cpu.hpp
@@ -36,5 +36,10 @@ float median(const ndarray &a, std::vector<int64_t> axes={});
 // ndarray median(const ndarray &a, std::vector<int64_t> axes={});
 // ndarray median(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 
+/**
+ * return the number of elements that will evaluate to true
+ */
+int64_t count_true(ndarray x);
+
 } // namespace cpu
 } // namespace bland

--- a/bland/bland/ops/cuda/comparison_cuda.cu
+++ b/bland/bland/ops/cuda/comparison_cuda.cu
@@ -7,7 +7,6 @@
 #include "elementwise_scalar_op_cuda.cuh"
 
 #include "comparison_cuda_impl.cuh"
-#include "count.cuh" // kernel definition for count
 
 using namespace bland;
 using namespace bland::cuda;
@@ -54,6 +53,9 @@ template ndarray bland::cuda::greater_than<int8_t, ndarray>(int8_t lhs, ndarray 
 template ndarray bland::cuda::greater_than<int16_t, ndarray>(int16_t lhs, ndarray rhs);
 template ndarray bland::cuda::greater_than<int32_t, ndarray>(int32_t lhs, ndarray rhs);
 template ndarray bland::cuda::greater_than<int64_t, ndarray>(int64_t lhs, ndarray rhs);
+
+template ndarray bland::cuda::greater_than<uint8_t, ndarray_slice>(uint8_t lhs, ndarray_slice rhs);
+template ndarray bland::cuda::greater_than<ndarray_slice, uint8_t>(ndarray_slice lhs, uint8_t rhs);
 
 
 /**
@@ -231,6 +233,8 @@ template ndarray bland::cuda::logical_and<int16_t, ndarray>(int16_t lhs, ndarray
 template ndarray bland::cuda::logical_and<int32_t, ndarray>(int32_t lhs, ndarray rhs);
 template ndarray bland::cuda::logical_and<int64_t, ndarray>(int64_t lhs, ndarray rhs);
 
+template ndarray bland::cuda::logical_and<uint8_t, ndarray_slice>(uint8_t lhs, ndarray_slice rhs);
+template ndarray bland::cuda::logical_and<ndarray_slice, uint8_t>(ndarray_slice lhs, uint8_t rhs);
 
 /**
  * equal_to
@@ -275,7 +279,3 @@ template ndarray bland::cuda::equal_to<int16_t, ndarray>(int16_t lhs, ndarray rh
 template ndarray bland::cuda::equal_to<int32_t, ndarray>(int32_t lhs, ndarray rhs);
 template ndarray bland::cuda::equal_to<int64_t, ndarray>(int64_t lhs, ndarray rhs);
 
-
-int64_t bland::cuda::count_true(ndarray x) {
-    return dispatch_summary<count_launcher>(x);
-}

--- a/bland/bland/ops/cuda/comparison_cuda.cuh
+++ b/bland/bland/ops/cuda/comparison_cuda.cuh
@@ -27,10 +27,5 @@ ndarray logical_and(L lhs, R rhs);
 template <typename L, typename R>
 ndarray equal_to(L lhs, R rhs);
 
-/**
- * return the number of elements that will evaluate to true
- */
-int64_t count_true(ndarray x);
-
 } // namespace cuda
 } // namespace bland

--- a/bland/bland/ops/cuda/elementwise_unary_op.cuh
+++ b/bland/bland/ops/cuda/elementwise_unary_op.cuh
@@ -12,24 +12,30 @@
 #include <cuda_runtime.h>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace bland {
 namespace cuda {
 
 
+// TODO: have a safe default if ndim > MAX_NDIM
+constexpr int MAX_NDIM=4;
+
 template <typename Out, typename A, template <typename, typename> class Op>
 __global__ void elementwise_unary_op_impl(Out* out_data, int64_t* out_shape, int64_t* out_strides,
                                 A* a_data, int64_t* a_shape, int64_t* a_strides,
                                 int64_t ndim, int64_t numel) {
-    auto worker_id = gridDim.x * blockIdx.x + threadIdx.x;
+    auto worker_id = blockIdx.x * blockDim.x + threadIdx.x;
     auto grid_size = gridDim.x * blockDim.x;
 
-    int64_t* nd_index = (int64_t*) malloc(ndim * sizeof(int64_t));
+    // int64_t* nd_index = (int64_t*) malloc(ndim * sizeof(int64_t));
+    int64_t nd_index[MAX_NDIM] = {0};
     auto flattened_work_item = worker_id;
     for (int dim = ndim - 1; dim >= 0; --dim) {
         nd_index[dim] = flattened_work_item % out_shape[dim];
         flattened_work_item /= out_shape[dim];
     }
+    // printf("initial index: [%i]: [%lld, %lld]\n", worker_id, nd_index[0], nd_index[1]);
 
     for (int64_t n = worker_id; n < numel; n += grid_size) {
         int64_t out_index = 0, a_index = 0;
@@ -38,10 +44,10 @@ __global__ void elementwise_unary_op_impl(Out* out_data, int64_t* out_shape, int
             a_index += nd_index[dim] * a_strides[dim];
         }
         out_data[out_index] = Op<Out, A>::call(a_data[a_index]);
-        // printf("storing %f [%lld] = f(%f [%lld], %f [%lld]) at ind=%i with tid=%i.%i\n", out_data[out_index], out_index,
+        // __syncthreads();
+        // printf("storing %i [%lld] = f(%i [%lld]) at ind=%i  ([%lld, %lld]) with tid=%i.%i\n", out_data[out_index], out_index,
         //                                                                         a_data[a_index], a_index,
-        //                                                                         b_data[b_index], b_index,
-        //                                                                         n, threadIdx.x, blockIdx.x);
+        //                                                                         n, nd_index[0], nd_index[1], blockIdx.x, threadIdx.x);
 
         auto increment_amount = grid_size;
         for (int dim = ndim - 1; dim >= 0; --dim) {
@@ -55,7 +61,7 @@ __global__ void elementwise_unary_op_impl(Out* out_data, int64_t* out_shape, int
             }
         }
     }
-    free(nd_index);
+    // free(nd_index);
 }
 /**
  * template wrapper around a template function which calls the function
@@ -64,19 +70,20 @@ __global__ void elementwise_unary_op_impl(Out* out_data, int64_t* out_shape, int
 struct unary_op_impl_wrapper {
     template <typename Out, typename A_type, template <typename, typename> class Op>
     static inline ndarray call(ndarray out, const ndarray &a) {
-        // Check that this operation is possible
-        auto a_shape = a.shape();
-        auto a_data = a.data_ptr<A_type>();
-        
         const auto a_offset   = a.offsets();
         const auto out_offset = out.offsets();
-        
-        auto       out_data  = out.data_ptr<Out>();
+        int64_t a_ptr_offset = std::accumulate(a_offset.begin(), a_offset.end(), 0LL);
+        int64_t out_ptr_offset = std::accumulate(out_offset.begin(), out_offset.end(), 0LL);
+
+        auto a_data = a.data_ptr<A_type>() + a_ptr_offset;
+        auto a_shape = a.shape();
+
+        auto       out_data  = out.data_ptr<Out>() + out_ptr_offset;
         const auto out_shape = out.shape();
-        
+
         const auto a_strides   = compute_broadcast_strides(a.shape(), a.strides(), out_shape);
         const auto out_strides = out.strides();
-        
+
         a_shape = compute_broadcast_shape(a_shape, out_shape);
 
         thrust::device_vector<int64_t> dev_out_shape(out_shape.begin(), out_shape.end());
@@ -85,15 +92,31 @@ struct unary_op_impl_wrapper {
         thrust::device_vector<int64_t> dev_a_shape(a_shape.begin(), a_shape.end());
         thrust::device_vector<int64_t> dev_a_strides(a_strides.begin(), a_strides.end());
 
-        int block_size = 256; // TODO: for some small numels we might still want to reduce this
+        int block_size = 512; // TODO: for some small numels we might still want to reduce this
         auto numel = out.numel();
         // TODO: do some benchmarking to get a better default max number of blocks
-        int num_blocks = std::min<int>(16, (numel+block_size-1) / block_size);
+        int num_blocks = std::min<int>(32, (numel+block_size-1) / block_size);
         // cudaDeviceSynchronize();
+
         elementwise_unary_op_impl<Out, A_type, Op><<<num_blocks, block_size>>>(out_data, thrust::raw_pointer_cast(dev_out_shape.data()), thrust::raw_pointer_cast(dev_out_strides.data()),
                                                                 a_data, thrust::raw_pointer_cast(dev_a_shape.data()), thrust::raw_pointer_cast(dev_a_strides.data()),
                                                                 out.ndim(), numel);
-        // cudaDeviceSynchronize();
+        // // Synchronize the device
+        // cudaError_t syncErr = cudaDeviceSynchronize();
+
+        // // Check for errors in kernel launch
+        // cudaError_t launchErr = cudaGetLastError();
+        // if (syncErr != cudaSuccess) {
+        //     printf("Error during kernel execution: %s\n", cudaGetErrorString(syncErr));
+        // } else {
+        //     // printf("No error during kernel exec\n");
+        // }
+
+        // if (launchErr != cudaSuccess) {
+        //     printf("Error during kernel launch: %s\n", cudaGetErrorString(launchErr));
+        // } else {
+        //     // printf("no launch error\n");
+        // }
         return out;
     }
 };

--- a/bland/bland/ops/cuda/ops_cuda.cu
+++ b/bland/bland/ops/cuda/ops_cuda.cu
@@ -19,7 +19,6 @@ ndarray bland::cuda::copy(ndarray a, ndarray &out) {
 }
 
 ndarray bland::cuda::square(ndarray a, ndarray& out) {
-    fmt::print("in the cuda square(ndarray)\n");
     return dispatch_new2<cuda::unary_op_impl_wrapper, cuda::elementwise_square_op>(out, a);
 }
 
@@ -30,3 +29,101 @@ ndarray bland::cuda::sqrt(ndarray a, ndarray& out) {
 ndarray bland::cuda::abs(ndarray a, ndarray& out) {
     return dispatch_new2<cuda::unary_op_impl_wrapper, cuda::elementwise_abs_op>(out, a);
 }
+
+
+/**
+ * Fill out with the value of a cast to the datatype of out.
+ */
+// TODO: have a safe default if ndim > MAX_NDIM
+constexpr int ASSIGN_MAX_NDIM=4;
+
+template <typename Out, typename S>
+__global__ void assignment_kernel(Out* out_data, int64_t* out_shape, int64_t* out_strides,
+                                S value,
+                                int64_t ndim, int64_t numel) {
+    auto worker_id = blockIdx.x * blockDim.x + threadIdx.x;
+    auto grid_size = gridDim.x * blockDim.x;
+
+    int64_t nd_index[ASSIGN_MAX_NDIM] = {0};
+    auto flattened_work_item = worker_id;
+    for (int dim = ndim - 1; dim >= 0; --dim) {
+        nd_index[dim] = flattened_work_item % out_shape[dim];
+        flattened_work_item /= out_shape[dim];
+    }
+    for (int64_t n = worker_id; n < numel; n += grid_size) {
+        int64_t out_index = 0;
+        for (int dim = 0; dim < ndim; ++dim) {
+            out_index += nd_index[dim] * out_strides[dim];
+        }
+        out_data[out_index] = value;
+        auto increment_amount = grid_size;
+        for (int dim = ndim - 1; dim >= 0; --dim) {
+            nd_index[dim] += increment_amount;
+            if (nd_index[dim] < out_shape[dim]) {
+                break;
+            } else {
+                // The remainder might be multiples of dim sizes
+                increment_amount = nd_index[dim] / out_shape[dim];
+                nd_index[dim] = nd_index[dim] % out_shape[dim];
+            }
+        }
+    }
+}
+
+struct assignment_op_impl_wrapper {
+    template <typename Out, typename S>
+    static inline ndarray call(ndarray &out, const S &value) {
+        const auto out_offset = out.offsets();
+        int64_t out_ptr_offset = std::accumulate(out_offset.begin(), out_offset.end(), 0LL);
+
+        auto       out_data  = out.data_ptr<Out>() + out_ptr_offset;
+        const auto out_shape = out.shape();
+        const auto out_strides = out.strides();
+
+        thrust::device_vector<int64_t> dev_out_shape(out_shape.begin(), out_shape.end());
+        thrust::device_vector<int64_t> dev_out_strides(out_strides.begin(), out_strides.end());
+
+        int block_size = 512; // TODO: for some small numels we might still want to reduce this
+        auto numel = out.numel();
+        // TODO: do some benchmarking to get a better default max number of blocks
+        int num_blocks = std::min<int>(32, (numel+block_size-1) / block_size);
+        // cudaDeviceSynchronize();
+
+        assignment_kernel<Out, S><<<num_blocks, block_size>>>(out_data, thrust::raw_pointer_cast(dev_out_shape.data()), thrust::raw_pointer_cast(dev_out_strides.data()),
+value,
+                                                                out.ndim(), numel);
+        // // Synchronize the device
+        // cudaError_t syncErr = cudaDeviceSynchronize();
+
+        // // Check for errors in kernel launch
+        // cudaError_t launchErr = cudaGetLastError();
+        // if (syncErr != cudaSuccess) {
+        //     printf("Error during kernel execution: %s\n", cudaGetErrorString(syncErr));
+        // } else {
+        //     // printf("No error during kernel exec\n");
+        // }
+
+        // if (launchErr != cudaSuccess) {
+        //     printf("Error during kernel launch: %s\n", cudaGetErrorString(launchErr));
+        // } else {
+        //     // printf("no launch error\n");
+        // }
+        return out;
+    }
+};
+
+template <typename T>
+ndarray bland::cuda::fill(ndarray out, T value) {
+    return dispatch_new<assignment_op_impl_wrapper, T>(out, value);
+}
+
+template ndarray bland::cuda::fill<float>(ndarray out, float v);
+template ndarray bland::cuda::fill<double>(ndarray out, double v);
+template ndarray bland::cuda::fill<int8_t>(ndarray out, int8_t v);
+template ndarray bland::cuda::fill<int16_t>(ndarray out, int16_t v);
+template ndarray bland::cuda::fill<int32_t>(ndarray out, int32_t v);
+template ndarray bland::cuda::fill<int64_t>(ndarray out, int64_t v);
+template ndarray bland::cuda::fill<uint8_t>(ndarray out, uint8_t v);
+template ndarray bland::cuda::fill<uint16_t>(ndarray out, uint16_t v);
+template ndarray bland::cuda::fill<uint32_t>(ndarray out, uint32_t v);
+template ndarray bland::cuda::fill<uint64_t>(ndarray out, uint64_t v);

--- a/bland/bland/ops/cuda/ops_cuda.cuh
+++ b/bland/bland/ops/cuda/ops_cuda.cuh
@@ -11,5 +11,8 @@ ndarray square(ndarray a, ndarray& out);
 ndarray sqrt(ndarray a, ndarray& out);
 ndarray abs(ndarray a, ndarray& out);
 
+template <typename T>
+ndarray fill(ndarray out, T value);
+
 } // namespace cuda
 } // namespace bland

--- a/bland/bland/ops/cuda/statistical.cuh
+++ b/bland/bland/ops/cuda/statistical.cuh
@@ -38,5 +38,10 @@ float median(const ndarray &a, std::vector<int64_t> axes={});
 // ndarray median(const ndarray &a, std::vector<int64_t> axes={});
 // ndarray median(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 
+/**
+ * return the number of elements that will evaluate to true
+ */
+int64_t count_true(ndarray x);
+
 } // namespace cuda
 } // namespace bland

--- a/bland/bland/ops/device_dispatch.hpp
+++ b/bland/bland/ops/device_dispatch.hpp
@@ -15,17 +15,18 @@ inline ndarray device_dispatch(FuncCPU cpu_func, FuncCUDA cuda_func, L lhs, R rh
     
     ndarray::dev compute_device = default_device;
     // Check device consistency between arguments and set appropriate compute device
-    if constexpr (std::is_same<L, ndarray>::value && std::is_same<R, ndarray>::value) {
+    if constexpr (std::is_base_of<ndarray, std::decay_t<L>>::value && std::is_base_of<ndarray, std::decay_t<R>>::value) {
         if (lhs.device() == rhs.device()) {
             compute_device = rhs.device();
         } else {
             throw std::runtime_error("ERROR: got two arrays on different devices");
         }
-    } else if constexpr (std::is_same<L, ndarray>::value) {
+    } else if constexpr (std::is_base_of<ndarray, std::decay_t<L>>::value) {
         compute_device = lhs.device();
-    } else if constexpr (std::is_same<R, ndarray>::value) {
+    } else if constexpr (std::is_base_of<ndarray, std::decay_t<R>>::value) {
         compute_device = rhs.device();
     }
+    // fmt::print("compute device is {}\n", compute_device.device_type);
 
     // Call the correct function impl based on compute device
     if (compute_device.device_type == kDLCPU || compute_device.device_type == kDLCUDAHost) {

--- a/bland/bland/ops/ops.cpp
+++ b/bland/bland/ops/ops.cpp
@@ -4,7 +4,6 @@
 #include "bland/ndarray.hpp"
 
 #include "device_dispatch.hpp"
-#include "assignment_op.hpp"
 #include "dispatcher.hpp"
 #include "shape_helpers.hpp"
 #include <dlpack/dlpack.h> // consider if bland_tensor_internals.hpp which includes this is more appropriate
@@ -225,11 +224,25 @@ template ndarray_slice bland::slice(const ndarray &a,
 
 template <typename T>
 ndarray bland::fill(ndarray out, T value) {
-    return dispatch_new<assignment_op_impl_wrapper, T>(out, value);
+    auto compute_device = out.device();
+#if BLAND_CUDA_CODE
+    if (compute_device.device_type == ndarray::dev::cuda.device_type || compute_device.device_type == ndarray::dev::cuda_managed.device_type) {
+        return cuda::fill(out, value);
+    } else
+#endif // BLAND_CUDA_CODE
+    if (compute_device.device_type == ndarray::dev::cpu.device_type) {
+        return cpu::fill(out, value);
+    } else {
+        throw std::runtime_error("unsupported device for masked_stddev");
+    }
 }
 
 template ndarray bland::fill<float>(ndarray out, float v);
 template ndarray bland::fill<double>(ndarray out, double v);
+template ndarray bland::fill<uint8_t>(ndarray out, uint8_t v);
+template ndarray bland::fill<uint16_t>(ndarray out, uint16_t v);
+template ndarray bland::fill<uint32_t>(ndarray out, uint32_t v);
+template ndarray bland::fill<uint64_t>(ndarray out, uint64_t v);
 template ndarray bland::fill<int8_t>(ndarray out, int8_t v);
 template ndarray bland::fill<int16_t>(ndarray out, int16_t v);
 template ndarray bland::fill<int32_t>(ndarray out, int32_t v);

--- a/bland/bland/ops/statistical.cpp
+++ b/bland/bland/ops/statistical.cpp
@@ -276,3 +276,19 @@ ndarray bland::sum(const ndarray &a, std::vector<int64_t> reduced_axes) {
     ndarray out(out_shape, a.dtype(), a.device());
     return sum(a, out, reduced_axes);
 }
+
+int64_t bland::count_true(ndarray x) {
+    auto compute_device = x.device();
+
+#if BLAND_CUDA_CODE
+    if (compute_device.device_type == ndarray::dev::cuda.device_type || compute_device.device_type == ndarray::dev::cuda_managed.device_type) {
+        return cuda::count_true(x);
+    } else
+#endif // BLAND_CUDA_CODE
+    if (compute_device.device_type == ndarray::dev::cpu.device_type) {
+        return cpu::count_true(x);
+    } else {
+        throw std::runtime_error("unsupported device for count_true");
+    }
+
+}

--- a/bland/python/pybland.hpp
+++ b/bland/python/pybland.hpp
@@ -58,6 +58,11 @@ void bind_pybland(nb::module_ m) {
     )
     ;
 
+    nb::class_<bland::ndarray::dev>(m, "device")
+    .def(nb::init<std::string_view>())
+    ;
+
+
     m.def("arange", [](float start, float end, float step) {
         return bland::arange(start, end, step);
     });
@@ -118,8 +123,78 @@ void bind_pybland(nb::module_ m) {
     m.def("multiply", [](nb::ndarray<> a, nb::ndarray<> b) {
         return bland::multiply(nb_to_bland(a), nb_to_bland(b));
     });
+    m.def("multiply", [](nb::ndarray<> a, uint8_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, uint16_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, uint32_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, uint64_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, int8_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, int16_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, int32_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, int64_t b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, float b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+    m.def("multiply", [](nb::ndarray<> a, double b) {
+        return bland::multiply(nb_to_bland(a), b);
+    });
+
+
     m.def("divide", [](nb::ndarray<> a, nb::ndarray<> b) {
         return bland::divide(nb_to_bland(a), nb_to_bland(b));
+    });
+
+    m.def("less_than", [](nb::ndarray<> a, uint8_t b) {
+        return bland::less_than(nb_to_bland(a), b);
+    });
+    m.def("less_than", [](nb::ndarray<> a, uint16_t b) {
+        return bland::less_than(nb_to_bland(a), b);
+    });
+    m.def("less_than", [](nb::ndarray<> a, uint32_t b) {
+        return bland::less_than(nb_to_bland(a), b);
+    });
+    m.def("less_than", [](nb::ndarray<> a, uint64_t b) {
+        return bland::less_than(nb_to_bland(a), b);
+    });
+    m.def("less_than", [](nb::ndarray<> a, float b) {
+        return bland::less_than(nb_to_bland(a), b);
+    });
+    m.def("less_than", [](nb::ndarray<> a, int64_t b) {
+        return bland::less_than(nb_to_bland(a), b);
+    });
+
+    m.def("greater_than", [](nb::ndarray<> a, uint8_t b) {
+        return bland::greater_than(nb_to_bland(a), b);
+    });
+    m.def("greater_than", [](nb::ndarray<> a, uint16_t b) {
+        return bland::greater_than(nb_to_bland(a), b);
+    });
+    m.def("greater_than", [](nb::ndarray<> a, uint32_t b) {
+        return bland::greater_than(nb_to_bland(a), b);
+    });
+    m.def("greater_than", [](nb::ndarray<> a, uint64_t b) {
+        return bland::greater_than(nb_to_bland(a), b);
+    });
+    m.def("greater_than", [](nb::ndarray<> a, float b) {
+        return bland::greater_than(nb_to_bland(a), b);
+    });
+    m.def("greater_than", [](nb::ndarray<> a, int64_t b) {
+        return bland::greater_than(nb_to_bland(a), b);
     });
 
 

--- a/bland/tests/test_arithmetic.cpp
+++ b/bland/tests/test_arithmetic.cpp
@@ -169,7 +169,7 @@ TEST_CASE("cuda arithmetic", "[ops][arithmetic]") {
                                         0.0001f));
     }
     SECTION("array-scalar mul-add", "[10000, 10000] array * 4 + 2") {
-        auto test_array = bland::ndarray({10000, 10000}, 1.0f);
+        auto test_array = bland::ndarray({1024, 5}, 1.0f);
 
         test_array = test_array.to("cuda:0");
 
@@ -177,8 +177,9 @@ TEST_CASE("cuda arithmetic", "[ops][arithmetic]") {
         result = result.to("cpu");
         cudaDeviceSynchronize();
 
-        REQUIRE(test_array.numel() == 10000*10000);
+        REQUIRE(test_array.numel() == 1024*5);
         auto expected = std::vector<float>(test_array.numel(), 6.0f);
+        // REQUIRE(result.numel() == )
         REQUIRE_THAT(std::vector<float>(result.data_ptr<float>(), result.data_ptr<float>() + result.numel()),
                         BlandWithinAbs(expected,
                                 0.0001f));

--- a/bland/tests/test_statistical.cpp
+++ b/bland/tests/test_statistical.cpp
@@ -190,7 +190,6 @@ TEST_CASE("cuda statistical", "[ndarray][ops][statistical]") {
             REQUIRE_THAT(cuda_stddev.data_ptr<float>()[0], Catch::Matchers::WithinAbs(1.0f, .1));
             // REQUIRE_THAT(cuda_kurtosis.data_ptr<float>()[0], Catch::Matchers::WithinAbs(3.0f, .1));
     }
-
     SECTION("mean 2d axis", "test 2d mean and stddev with axis arguments on cuda") {
             auto test_array = bland::rand_normal(
                     {500000, 5}, 0.0f, 1.0f, DLDataType{.code = DLDataTypeCode::kDLFloat, .bits = 32});
@@ -242,6 +241,46 @@ TEST_CASE("cuda statistical", "[ndarray][ops][statistical]") {
 
             // REQUIRE_THAT(std::vector<float>(kurtosis.data_ptr<float>(), kurtosis.data_ptr<float>() + kurtosis.numel()),
             //              BlandWithinAbs(std::vector<float>{3, 3, 0, 3, 3}, .1f));
+    }
+    SECTION("sum 2d axis", "test 2d sum with axis arguments on cuda") {
+            auto test_array = bland::ndarray(
+                    {16, 50}, 42, DLDataType{.code = DLDataTypeCode::kDLFloat, .bits = 32});
+
+            test_array = test_array.to("cuda:0");
+
+            auto sum = bland::sum(test_array, {0});
+
+            sum = sum.to("cpu");
+            cudaDeviceSynchronize();
+
+            REQUIRE_THAT(std::vector<float>(sum.data_ptr<float>(), sum.data_ptr<float>() + sum.numel()),
+                         BlandWithinAbs(std::vector<float>(50, 42*16), .1f));
+
+
+        //     // Linear transform: mean and variance get scaled and translated, normalized moment should remain the same.
+        //     test_array = test_array.to("cpu");
+        //     cudaDeviceSynchronize();
+        //     test_array = test_array * 4 + 2;
+        //     cudaDeviceSynchronize();
+        //     test_array = test_array.to("cuda");
+        //     cudaDeviceSynchronize();
+
+        //     mean     = bland::mean(test_array, {0});
+        //     stddev   = bland::stddev(test_array, {0});
+        //     cudaDeviceSynchronize();
+        //     // kurtosis = bland::standardized_moment(test_array, 4, {0});
+        //     mean = mean.to("cpu");
+        //     stddev = stddev.to("cpu");
+        //     cudaDeviceSynchronize();
+
+        //     REQUIRE_THAT(std::vector<float>(mean.data_ptr<float>(), mean.data_ptr<float>() + mean.numel()),
+        //                  BlandWithinAbs(std::vector<float>{2, 10, 22, 2, 2}, .1f));
+
+        //     REQUIRE_THAT(std::vector<float>(stddev.data_ptr<float>(), stddev.data_ptr<float>() + stddev.numel()),
+        //                  BlandWithinAbs(std::vector<float>{4, 16, 0, 4, 4}, .1f));
+
+        //     // REQUIRE_THAT(std::vector<float>(kurtosis.data_ptr<float>(), kurtosis.data_ptr<float>() + kurtosis.numel()),
+        //     //              BlandWithinAbs(std::vector<float>{3, 3, 0, 3, 3}, .1f));
     }
 }
 

--- a/bland/tests/test_strides.cpp
+++ b/bland/tests/test_strides.cpp
@@ -3,6 +3,8 @@
 #include <catch2/matchers/catch_matchers_vector.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
+#include <fmt/format.h>
+
 #include <bland/bland.hpp>
 
 TEST_CASE("ndarray 1d stride", "[ndarray][stride]") {
@@ -73,3 +75,62 @@ TEST_CASE("ndarray 1d stride", "[ndarray][stride]") {
         REQUIRE_THAT(slice.shape(), Catch::Matchers::Equals(std::vector<int64_t>{2,2}));
     }
 }
+
+#if BLAND_CUDA_CODE
+#include <cuda_runtime.h>
+
+
+TEST_CASE("cuda-slices", "[ndarray][stride]") {
+    SECTION("sliced offset", "slice to make sure the operation starts at the correct offset") {
+        auto test_array = bland::arange(0, 1000, 1, DLDataType{.code = DLDataTypeCode::kDLInt, .bits = 32});
+        test_array = test_array.to("cuda:0");
+
+        auto first_slice = bland::slice(test_array, bland::slice_spec{0, 5, 30, 1});
+
+        first_slice = first_slice + 10;
+
+        test_array = test_array.to("cpu");
+        cudaDeviceSynchronize();
+
+        REQUIRE_THAT(std::vector<int32_t>(test_array.data_ptr<int32_t>(),
+                                            test_array.data_ptr<int32_t>() + 42),
+                        Catch::Matchers::Equals(std::vector<int32_t>{0, 1, 2, 3, 4, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+                        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41}));
+    }
+    SECTION("broadcasting add", "broadcasting...") {
+        auto test_array = bland::arange(0, 50, 1, DLDataType{.code = DLDataTypeCode::kDLFloat, .bits = 32});
+        auto test_array2 = test_array.to("cuda:0");
+
+        auto test_2d = bland::ndarray({5, 50}, 40, DLDataType{.code = DLDataTypeCode::kDLFloat, .bits = 32});
+        bland::fill(bland::slice(test_2d, bland::slice_spec({0, 1, 2, 1})), 50);
+
+        fmt::print("{}\n", test_2d.repr());
+        test_2d = test_2d.to("cuda:0");
+
+        cudaDeviceSynchronize();
+
+        auto result = test_2d + test_array2;
+        // auto result = test_array2 + test_2d;
+
+        REQUIRE_THAT(result.shape(), Catch::Matchers::Equals(std::vector<int64_t>{5, 50}));
+        // REQUIRE_THAT(slice.shape(), Catch::Matchers::Equals(std::vector<int64_t>{2,2}));
+
+        REQUIRE(result.numel() == 250);
+
+        result = result.to("cpu");
+        cudaDeviceSynchronize();
+
+        REQUIRE_THAT(std::vector<float>(result.data_ptr<float>(),
+                                            result.data_ptr<float>() + 50),
+            Catch::Matchers::Equals(std::vector<float>{40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+                                                        65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89}));
+
+        REQUIRE_THAT(std::vector<float>(result.data_ptr<float>() + 50,
+                                            result.data_ptr<float>() + 100),
+            Catch::Matchers::Equals(std::vector<float>{50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+                                                        80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99}));
+
+    }
+}
+
+#endif

--- a/bliss/core/coarse_channel.cpp
+++ b/bliss/core/coarse_channel.cpp
@@ -42,11 +42,13 @@ coarse_channel::coarse_channel(bland::ndarray data,
         _za_start(za_start) {
 }
 
-bland::ndarray bliss::coarse_channel::data() const {
+bland::ndarray bliss::coarse_channel::data() {
+    _data = _data.to(_device);
     return _data;
 }
 
-bland::ndarray bliss::coarse_channel::mask() const {
+bland::ndarray bliss::coarse_channel::mask() {
+    _mask = _mask.to(_device);
     return _mask;
 }
 
@@ -72,6 +74,16 @@ std::list<hit> bliss::coarse_channel::hits() const {
 
 void bliss::coarse_channel::add_hits(std::list<hit> new_hits) {
     _hits = new_hits;
+}
+
+bland::ndarray::dev bliss::coarse_channel::device() {
+    return _device;
+}
+
+void bliss::coarse_channel::set_device(bland::ndarray::dev &device) {
+    _device = device;
+    // TODO: what to do about data already read? Maybe just wait until it's been rerequested
+    // defer as much as possible
 }
 
 double bliss::coarse_channel::fch1() const {

--- a/bliss/core/include/core/cadence.hpp
+++ b/bliss/core/include/core/cadence.hpp
@@ -23,6 +23,9 @@ struct observation_target {
     */
     observation_target slice_observation_channels(int start_channel=0, int count=1);
 
+    // bland::ndarray::dev device();
+    // void set_device(bland::ndarray::dev &device);
+
     // Is it useful to capture which of ABACAD this is?
     std::vector<scan> _scans;
     std::string       _target_name;
@@ -56,6 +59,9 @@ struct cadence {
      * create a new cadence consisting of a slice of coarse channels
     */
     cadence slice_cadence_channels(int start_channel=0, int count=1);
+
+    // bland::ndarray::dev device();
+    // void set_device(bland::ndarray::dev &device);
 
   protected:
 };

--- a/bliss/core/include/core/coarse_channel.hpp
+++ b/bliss/core/include/core/coarse_channel.hpp
@@ -35,8 +35,8 @@ struct coarse_channel {
                    int64_t        data_type,
                    double         az_start,
                    double         za_start);
-    bland::ndarray data() const;
-    bland::ndarray mask() const;
+    bland::ndarray data();
+    bland::ndarray mask();
     void           set_mask(bland::ndarray new_mask);
 
     frequency_drift_plane integrated_drift_plane();
@@ -48,6 +48,14 @@ struct coarse_channel {
     bool           has_hits();
     std::list<hit> hits() const;
     void           add_hits(std::list<hit> new_hits);
+
+    bland::ndarray::dev device();
+
+    /**
+     * Set the compute device for this coarse_channel. When `data` or `mask` is requested, it will first
+     * be sent to this device if it is not already there.
+    */
+    void set_device(bland::ndarray::dev &device);
 
     double fch1() const;
     // void        fch1(double);
@@ -108,10 +116,7 @@ struct coarse_channel {
     std::optional<bland::ndarray>           _dedrifted_spectrum;
     std::optional<integrated_flags>         _dedrifted_rfi;
 
-
-    // TODO: I do not think we need to carry this around anymore since we'll track everything needed
-    // in the frequency_drift_plane object
-    std::optional<integrate_drifts_options> _drift_parameters;
+    bland::ndarray::dev _device = bland::ndarray::dev::cpu;
 
     std::optional<std::list<hit>> _hits;
 };

--- a/bliss/core/include/core/frequency_drift_plane.hpp
+++ b/bliss/core/include/core/frequency_drift_plane.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "integrate_drifts_options.hpp" // integrated_flags
+
 #include <bland/ndarray.hpp>
 
 #include <cstdint>

--- a/bliss/core/include/core/pyblisscore.hpp
+++ b/bliss/core/include/core/pyblisscore.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <bland/ndarray.hpp>
 #include "cadence.hpp"
 #include "coarse_channel.hpp"
 #include "scan.hpp"
+#include <variant>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
@@ -13,6 +15,7 @@
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/tuple.h>
+#include <nanobind/stl/variant.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -43,7 +46,7 @@ void bind_pycore(nb::module_ m) {
             .def_ro("za_start", &bliss::coarse_channel::_za_start)
             .def_ro("noise_estimate", &bliss::coarse_channel::_noise_stats)
             .def("integrated_drift_plane", &bliss::coarse_channel::integrated_drift_plane)
-                ;
+            .def_prop_rw("device", &bliss::coarse_channel::device, &bliss::coarse_channel::set_device);
 
     nb::class_<bliss::scan>(m, "scan")
             .def(nb::init<std::string_view>(), "file_path"_a)
@@ -67,7 +70,15 @@ void bind_pycore(nb::module_ m) {
             .def_prop_ro("tsamp", &bliss::scan::tsamp)
             .def_prop_ro("tstart", &bliss::scan::tstart)
             .def_prop_ro("za_start", &bliss::scan::za_start)
-        ;
+            .def_prop_rw("device", &bliss::scan::device,
+                                   [](bliss::scan &t, std::variant<int, std::string_view> value) {
+                                       if (std::holds_alternative<std::string_view>(value)) {
+                                            t.set_device(std::get<std::string_view>(value));
+                                       } else if (std::holds_alternative<int>(value)) {
+                                            // TODO: handle the case its actually a dev object
+                                            //t.set_device(std::get<bland::ndarray::dev>(value));
+                                       }
+                                   });
 
     //  * *DIMENSION_LABELS
     //  * *az_start

--- a/bliss/core/include/core/scan.hpp
+++ b/bliss/core/include/core/scan.hpp
@@ -120,6 +120,8 @@ class scan {
      * return the coarse channel index that the given frequency is in
      * 
      * useful for reinvestigating hits by looking up frequency
+     * 
+     * In the future this may change name or return the actual coarse channel
     */
     int get_coarse_channel_with_frequency(double frequency);
 
@@ -135,6 +137,10 @@ class scan {
      * gather hits in all coarse channels of this scan and return as a single list
      */
     std::list<hit> hits();
+
+    bland::ndarray::dev device();
+    void set_device(bland::ndarray::dev &device);
+    void set_device(std::string_view device);
 
     /**
      * create a new scan consisting of the selected coarse channel
@@ -208,6 +214,8 @@ class scan {
     // slow time is number of spectra
     int64_t _slow_time_bins;
     double  _tduration_secs;
+
+    bland::ndarray::dev _device = bland::ndarray::dev::cpu;
 
   private:
 };

--- a/bliss/drift_search/kernels/drift_integration_bland.cpp
+++ b/bliss/drift_search/kernels/drift_integration_bland.cpp
@@ -26,9 +26,10 @@ using namespace bliss;
 constexpr bool collect_rfi = true;
 // template <bool collect_rfi>
 [[nodiscard]] frequency_drift_plane
-bliss::integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_grid,
-                                     const bland::ndarray    &rfi_mask,
-                                     integrate_drifts_options options) {
+bliss::integrate_linear_rounded_bins_bland(const bland::ndarray &spectrum_grid,
+                                     const bland::ndarray       &rfi_mask,
+                                     integrate_drifts_options    options) {
+
     auto number_drifts = (options.high_rate - options.low_rate) / options.rate_step_size;
     std::vector<frequency_drift_plane::drift_rate> drift_rate_info;
 
@@ -181,14 +182,17 @@ bliss::integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_gri
                                 bland::slice(rfi_in_drift.filter_rolloff,
                                              bland::slice_spec{0, drift_index, drift_index + 1},
                                              bland::slice_spec{1, drift_freq_slice_start, drift_freq_slice_end});
+
                         filter_rolloff_slice = filter_rolloff_slice +
                                                (rfi_mask_slice & static_cast<uint8_t>(flag_values::filter_rolloff)) /
                                                        static_cast<uint8_t>(flag_values::filter_rolloff);
+
 
                         auto low_spectral_kurtosis_slice =
                                 bland::slice(rfi_in_drift.low_spectral_kurtosis,
                                              bland::slice_spec{0, drift_index, drift_index + 1},
                                              bland::slice_spec{1, drift_freq_slice_start, drift_freq_slice_end});
+
                         low_spectral_kurtosis_slice =
                                 low_spectral_kurtosis_slice +
                                 (rfi_mask_slice & static_cast<uint8_t>(flag_values::low_spectral_kurtosis)) /
@@ -198,6 +202,7 @@ bliss::integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_gri
                                 bland::slice(rfi_in_drift.high_spectral_kurtosis,
                                              bland::slice_spec{0, drift_index, drift_index + 1},
                                              bland::slice_spec{1, drift_freq_slice_start, drift_freq_slice_end});
+
                         high_spectral_kurtosis_slice =
                                 high_spectral_kurtosis_slice +
                                 (rfi_mask_slice & static_cast<uint8_t>(flag_values::high_spectral_kurtosis)) /

--- a/bliss/drift_search/kernels/drift_integration_bland.hpp
+++ b/bliss/drift_search/kernels/drift_integration_bland.hpp
@@ -22,9 +22,9 @@ namespace bliss {
  * value 0/7, 1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7.
  */
 [[nodiscard]] frequency_drift_plane
-integrate_linear_rounded_bins_bland(const bland::ndarray    &spectrum_grid,
-                              const bland::ndarray    &rfi_mask,
-                              integrate_drifts_options options);
+integrate_linear_rounded_bins_bland(const bland::ndarray &spectrum_grid,
+                              const bland::ndarray       &rfi_mask,
+                              integrate_drifts_options   options);
 
 bland::ndarray integrate_linear_rounded_bins_bland(const bland::ndarray &spectrum_grid, integrate_drifts_options options);
 

--- a/bliss/estimators/noise_estimate.cpp
+++ b/bliss/estimators/noise_estimate.cpp
@@ -124,7 +124,7 @@ bland::ndarray correct_mask(const bland::ndarray &mask) {
         // * warn earlier in flagging step
         throw std::runtime_error("correct_mask: the mask is completely flagged");
     }
-    // auto corrected_mask = bland::copy(mask);
+    auto corrected_mask = bland::copy(mask);
     return mask;
 }
 

--- a/bliss/flaggers/spectral_kurtosis.cpp
+++ b/bliss/flaggers/spectral_kurtosis.cpp
@@ -38,9 +38,9 @@ coarse_channel bliss::flag_spectral_kurtosis(coarse_channel cc_data, float lower
     // 2. Generate SK flag
     auto rfi = flag_spectral_kurtosis(spectrum_grid, N, M, d, lower_threshold, upper_threshold);
 
-    fmt::print("Storing sk mask back to coarse channel data\n");
+    auto accumulated_rfi = rfi_flags + rfi;
     // 3. Store back accumulated rfi
-    cc_data.set_mask(rfi_flags + rfi);
+    cc_data.set_mask(accumulated_rfi);
 
     return cc_data;
 }


### PR DESCRIPTION
* add device attributes for scan and coarse_channel
* fixed cuda initialized worker thread ids from using wrong magic grid dims in worker_id calculation
* fixed reductions not reinitializing (to zero) the shared memory accumulator for each output
* wrote unit tests for fixed bugs
* added python bindings that expose operations that were broken
* reduced some unnecessary verbosity
* add missing cuda ops for flagging, noise estimation, and dedrift integration pipeline


I've validated in a notebook the detection plane looks correct compared to cpu equivalent that's well validated.

Closes #11 