### PR TITLE
Pipeline api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ project(
     VERSION 0.0.0
     LANGUAGES CXX
 )
+
+include(CMakeDependentOption)
+include(FeatureSummary)
 # We don't actually need C, but there's an issue with debian packaging of cap'n proto
 # that causes gcc to fail
 # https://github.com/chaincodelabs/libmultiprocess/issues/68
@@ -22,6 +25,25 @@ enable_language(C)
 
 include(CheckLanguage)
 check_language(CUDA)
+
+find_package(CUDAToolkit)
+if (CUDAToolkit_FOUND)
+    message("CUDAToolkit_FOUND")
+endif()
+
+cmake_dependent_option(WITH_CUDA "Enable CUDA for bliss operations" ON "CMAKE_CUDA_COMPILER;CUDAToolkit_FOUND" OFF)
+add_feature_info(CUDA WITH_CUDA "Enabling bliss-specific CUDA operations")
+
+if (WITH_CUDA)
+  message("**BLISS:: enabling cuda (the language)")
+  if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    set(CMAKE_CUDA_ARCHITECTURES native)
+  endif()
+  enable_language(CUDA)
+  add_definitions("-DBLISS_CUDA=1")
+else()
+  message("**BLISS:: CUDA not found, building without it")
+endif()
 
 ##
 # options
@@ -88,11 +110,8 @@ include(CheckIPOSupported)
 check_ipo_supported(RESULT IPO_AVAILABLE)
 
 if (${IPO_AVAILABLE})
-  message("Can add flto")
+  message("**BLISS:: Can add flto")
 endif()
-
-include(CMakeDependentOption)
-include(FeatureSummary)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
@@ -116,7 +135,7 @@ if (NOT CapnProto_FOUND)
   # TODO: try to scope these better
   set(CMAKE_CXX_EXTENSIONS ON)
   set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "Enable position independent code")
-  message("**BLISS: capn proto not found. Attempting to pull in as an external project (and enabling CXX extensions)")
+  message("**BLISS:: capn proto not found. Attempting to pull in as an external project (and enabling CXX extensions)")
   # Cap'n proto (de)serialization library
   FetchContent_Declare(
     external_capnproto

--- a/bland/bland/include/bland/ndarray.hpp
+++ b/bland/bland/include/bland/ndarray.hpp
@@ -52,6 +52,7 @@ class ndarray {
         bool operator==(const dev &other);
         bool operator==(const DLDevice &other);
         bool operator!=(const dev &other);
+        std::string repr();
 
         static constexpr DLDevice cpu          = DLDevice{.device_type = kDLCPU, .device_id = 0};
         static constexpr DLDevice cuda         = DLDevice{.device_type = kDLCUDA, .device_id = 0};

--- a/bland/bland/ndarray.cpp
+++ b/bland/bland/ndarray.cpp
@@ -83,6 +83,11 @@ bool bland::ndarray::dev::operator!=(const dev &other) {
     return !(*this == other);
 }
 
+std::string bland::ndarray::dev::repr() {
+    auto r = fmt::format("ndarray::dev (.device_type={}, .device_id={})\n", device_type, device_id);
+    return r;
+}
+
 bland::ndarray::dev::dev(std::string_view dev_str) {
     if (dev_str == "cpu") {
 		device_type = DLDeviceType::kDLCPU;

--- a/bland/bland/ops/cuda/elementwise_binary_op_cuda.cuh
+++ b/bland/bland/ops/cuda/elementwise_binary_op_cuda.cuh
@@ -25,7 +25,7 @@ elementwise_binary_op_cuda_impl(Out* out_data, int64_t* out_shape, int64_t* out_
     auto worker_id = blockIdx.x * blockDim.x + threadIdx.x;
     auto grid_size = gridDim.x * blockDim.x;
 
-    int64_t nd_index[BINARY_MAX_NDIM] = {0};
+    uint32_t nd_index[BINARY_MAX_NDIM] = {0};
 
     auto flattened_work_item = worker_id;
     for (int dim = ndim - 1; dim >= 0; --dim) {
@@ -33,8 +33,8 @@ elementwise_binary_op_cuda_impl(Out* out_data, int64_t* out_shape, int64_t* out_
         flattened_work_item /= out_shape[dim];
     }
 
-    for (int64_t n = worker_id; n < numel; n += grid_size) {
-        int64_t out_index = 0, a_index = 0, b_index = 0;
+    for (uint32_t n = worker_id; n < numel; n += grid_size) {
+        uint32_t out_index = 0, a_index = 0, b_index = 0;
         for (int dim = 0; dim < ndim; ++dim) {
             out_index += nd_index[dim] * out_strides[dim];
             a_index += nd_index[dim] * a_strides[dim];

--- a/bland/bland/ops/cuda/elementwise_scalar_op_cuda.cuh
+++ b/bland/bland/ops/cuda/elementwise_scalar_op_cuda.cuh
@@ -34,15 +34,15 @@ __global__ void elementwise_scalar_op_cuda_impl(Out* out_data, int64_t* out_shap
     auto worker_id = blockIdx.x * blockDim.x + threadIdx.x;
     auto grid_size = gridDim.x * blockDim.x;
 
-    int64_t nd_index[SCALAR_MAX_NDIM] = {0};
+    uint32_t nd_index[SCALAR_MAX_NDIM] = {0};
     auto flattened_work_item = worker_id;
     for (int dim = ndim - 1; dim >= 0; --dim) {
         nd_index[dim] = flattened_work_item % out_shape[dim];
         flattened_work_item /= out_shape[dim];
     }
 
-    for (int64_t n = worker_id; n < numel; n += grid_size) {
-        int64_t out_index = 0, a_index = 0;
+    for (uint32_t n = worker_id; n < numel; n += grid_size) {
+        uint32_t out_index = 0, a_index = 0;
         for (int dim = 0; dim < ndim; ++dim) {
             out_index += nd_index[dim] * out_strides[dim];
             a_index += nd_index[dim] * a_strides[dim];

--- a/bland/bland/ops/cuda/elementwise_unary_op.cuh
+++ b/bland/bland/ops/cuda/elementwise_unary_op.cuh
@@ -28,8 +28,7 @@ __global__ void elementwise_unary_op_impl(Out* out_data, int64_t* out_shape, int
     auto worker_id = blockIdx.x * blockDim.x + threadIdx.x;
     auto grid_size = gridDim.x * blockDim.x;
 
-    // int64_t* nd_index = (int64_t*) malloc(ndim * sizeof(int64_t));
-    int64_t nd_index[MAX_NDIM] = {0};
+    uint32_t nd_index[MAX_NDIM] = {0};
     auto flattened_work_item = worker_id;
     for (int dim = ndim - 1; dim >= 0; --dim) {
         nd_index[dim] = flattened_work_item % out_shape[dim];
@@ -37,8 +36,8 @@ __global__ void elementwise_unary_op_impl(Out* out_data, int64_t* out_shape, int
     }
     // printf("initial index: [%i]: [%lld, %lld]\n", worker_id, nd_index[0], nd_index[1]);
 
-    for (int64_t n = worker_id; n < numel; n += grid_size) {
-        int64_t out_index = 0, a_index = 0;
+    for (uint32_t n = worker_id; n < numel; n += grid_size) {
+        uint32_t out_index = 0, a_index = 0;
         for (int dim = 0; dim < ndim; ++dim) {
             out_index += nd_index[dim] * out_strides[dim];
             a_index += nd_index[dim] * a_strides[dim];
@@ -61,8 +60,8 @@ __global__ void elementwise_unary_op_impl(Out* out_data, int64_t* out_shape, int
             }
         }
     }
-    // free(nd_index);
 }
+
 /**
  * template wrapper around a template function which calls the function
  * with the given template datatypes

--- a/bland/python/pybland.hpp
+++ b/bland/python/pybland.hpp
@@ -16,7 +16,8 @@ bland::ndarray nb_to_bland(nb::ndarray<> t);
 void bind_pybland(nb::module_ m) {
 
     // Define ndarray type
-    nb::class_<bland::ndarray>(m, "ndarray")
+    auto pyndarray = nb::class_<bland::ndarray>(m, "ndarray");
+    pyndarray
     .def(nb::init<std::vector<int64_t>>())
     .def("__repr__", &bland::ndarray::repr)
     .def("__dlpack__", [](bland::ndarray &self) {
@@ -58,9 +59,11 @@ void bind_pybland(nb::module_ m) {
     )
     ;
 
-    nb::class_<bland::ndarray::dev>(m, "device")
+    nb::class_<bland::ndarray::dev>(pyndarray, "dev")
     .def(nb::init<std::string_view>())
-    ;
+    .def_rw("device_type", &bland::ndarray::dev::device_type)
+    .def_rw("device_id", &bland::ndarray::dev::device_id)
+    .def("__repr__", &bland::ndarray::dev::repr);
 
 
     m.def("arange", [](float start, float end, float step) {

--- a/bliss/core/CMakeLists.txt
+++ b/bliss/core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(bliss_core
     cadence.cpp
     coarse_channel.cpp
     event.cpp
+    frequency_drift_plane.cpp
     hit.cpp
     noise_power.cpp
     scan.cpp

--- a/bliss/core/cadence.cpp
+++ b/bliss/core/cadence.cpp
@@ -49,6 +49,22 @@ bliss::observation_target bliss::observation_target::slice_observation_channels(
     return target_coarse_channel;
 }
 
+bland::ndarray::dev bliss::observation_target::device() {
+    return _device;
+}
+
+void bliss::observation_target::set_device(bland::ndarray::dev& device) {
+    for (auto &target_scan : _scans) {
+        target_scan.set_device(device);
+    }
+}
+
+void bliss::observation_target::set_device(std::string_view dev_str) {
+    bland::ndarray::dev device = dev_str;
+    set_device(device);
+}
+
+
 bliss::cadence::cadence(std::vector<observation_target> observations) : _observations(observations) {}
 
 bliss::cadence::cadence(std::vector<std::vector<std::string_view>> observations) {
@@ -63,4 +79,19 @@ bliss::cadence bliss::cadence::slice_cadence_channels(int start_channel, int cou
         cadence_coarse_channel._observations.push_back(obs.slice_observation_channels(start_channel, count));
     }
     return cadence_coarse_channel;
+}
+
+bland::ndarray::dev bliss::cadence::device() {
+    return _device;
+}
+
+void bliss::cadence::set_device(bland::ndarray::dev& device) {
+    for (auto &target : _observations) {
+        target.set_device(device);
+    }
+}
+
+void bliss::cadence::set_device(std::string_view dev_str) {
+    bland::ndarray::dev device = dev_str;
+    set_device(device);
 }

--- a/bliss/core/coarse_channel.cpp
+++ b/bliss/core/coarse_channel.cpp
@@ -53,7 +53,7 @@ bland::ndarray bliss::coarse_channel::mask() {
 }
 
 void bliss::coarse_channel::set_mask(bland::ndarray new_mask) {
-    _mask = new_mask;
+    _mask = new_mask; // TODO: should we send _mask to _device?
 }
 
 noise_stats bliss::coarse_channel::noise_estimate() const {
@@ -82,8 +82,13 @@ bland::ndarray::dev bliss::coarse_channel::device() {
 
 void bliss::coarse_channel::set_device(bland::ndarray::dev &device) {
     _device = device;
-    // TODO: what to do about data already read? Maybe just wait until it's been rerequested
-    // defer as much as possible
+    if (_integrated_drift_plane.has_value()) {
+        _integrated_drift_plane.value().set_device(_device);
+    }
+}
+
+void bliss::coarse_channel::set_device(std::string_view device) {
+    _device = device;
 }
 
 double bliss::coarse_channel::fch1() const {
@@ -192,9 +197,11 @@ double bliss::coarse_channel::za_start() const {
 // }
 
 frequency_drift_plane bliss::coarse_channel::integrated_drift_plane() {
-    return _integrated_drift_plane.value();
+    auto ddp = _integrated_drift_plane.value();
+    ddp.set_device(_device);
+    return ddp;
 }
 
 void bliss::coarse_channel::set_integrated_drift_plane(frequency_drift_plane integrated_plane) {
-    _integrated_drift_plane = integrated_plane;
+    _integrated_drift_plane = integrated_plane; // TODO: should we call set_device(_device)
 }

--- a/bliss/core/frequency_drift_plane.cpp
+++ b/bliss/core/frequency_drift_plane.cpp
@@ -1,0 +1,39 @@
+#include <core/frequency_drift_plane.hpp>
+
+
+using namespace bliss;
+
+
+bliss::frequency_drift_plane::frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi) : _integrated_drifts(drift_plane), _dedrifted_rfi(drift_rfi), _device(drift_plane.device()) {}
+
+bliss::frequency_drift_plane::frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi, int64_t integration_steps, std::vector<bliss::frequency_drift_plane::drift_rate> dri) : 
+    _integrated_drifts(drift_plane), _dedrifted_rfi(drift_rfi), _integration_steps(integration_steps), _drift_rate_info(dri), _device(drift_plane.device()) {
+}
+
+int64_t bliss::frequency_drift_plane::integration_steps() {
+    return _integration_steps;
+}
+
+std::vector<bliss::frequency_drift_plane::drift_rate> bliss::frequency_drift_plane::drift_rate_info() {
+    return _drift_rate_info;
+}
+
+bland::ndarray bliss::frequency_drift_plane::integrated_drift_plane(){
+    return _integrated_drifts;
+}
+
+integrated_flags bliss::frequency_drift_plane::integrated_rfi(){
+    return _dedrifted_rfi;
+}
+
+void bliss::frequency_drift_plane::set_device(bland::ndarray::dev dev) {
+    _device = dev;
+    _dedrifted_rfi.set_device(_device);
+    _integrated_drifts = _integrated_drifts.to(_device);
+}
+
+void bliss::frequency_drift_plane::set_device(std::string_view dev_str) {
+    auto dev = bland::ndarray::dev(dev_str);
+    set_device(dev);
+}
+

--- a/bliss/core/include/core/cadence.hpp
+++ b/bliss/core/include/core/cadence.hpp
@@ -23,12 +23,16 @@ struct observation_target {
     */
     observation_target slice_observation_channels(int start_channel=0, int count=1);
 
-    // bland::ndarray::dev device();
-    // void set_device(bland::ndarray::dev &device);
+    bland::ndarray::dev device();
+    void set_device(bland::ndarray::dev &device);
+    void set_device(std::string_view device_str);
 
     // Is it useful to capture which of ABACAD this is?
     std::vector<scan> _scans;
     std::string       _target_name;
+
+  protected:
+    bland::ndarray::dev _device = default_device;
 };
 
 /**
@@ -60,9 +64,11 @@ struct cadence {
     */
     cadence slice_cadence_channels(int start_channel=0, int count=1);
 
-    // bland::ndarray::dev device();
-    // void set_device(bland::ndarray::dev &device);
+    bland::ndarray::dev device();
+    void set_device(bland::ndarray::dev &device);
+    void set_device(std::string_view device_str);
 
   protected:
+    bland::ndarray::dev _device = default_device;
 };
 } // namespace bliss

--- a/bliss/core/include/core/coarse_channel.hpp
+++ b/bliss/core/include/core/coarse_channel.hpp
@@ -56,6 +56,7 @@ struct coarse_channel {
      * be sent to this device if it is not already there.
     */
     void set_device(bland::ndarray::dev &device);
+    void set_device(std::string_view device);
 
     double fch1() const;
     // void        fch1(double);

--- a/bliss/core/include/core/frequency_drift_plane.hpp
+++ b/bliss/core/include/core/frequency_drift_plane.hpp
@@ -9,7 +9,8 @@
 
 namespace bliss {
 
-struct frequency_drift_plane {
+class frequency_drift_plane {
+    public:
     struct drift_rate {
             int index_in_plane;
             double drift_rate_slope = 0.0F;
@@ -17,12 +18,25 @@ struct frequency_drift_plane {
             int desmeared_bins=1; // number of bins per spectra used to desmear
     };
 
-    frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi) : _integrated_drifts(drift_plane), _dedrifted_rfi(drift_rfi) {}
-    frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi, int64_t integration_steps, std::vector<drift_rate> dri) : 
-        _integrated_drifts(drift_plane), _dedrifted_rfi(drift_rfi), _integration_steps(integration_steps), _drift_rate_info(dri) {
-    }
-    
+    frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi);
+    frequency_drift_plane(bland::ndarray drift_plane, integrated_flags drift_rfi, int64_t integration_steps, std::vector<drift_rate> dri);
 
+    int64_t integration_steps();
+    // void set_integration_steps(int64_t integration_steps);
+
+    std::vector<drift_rate> drift_rate_info();
+    // void set_drift_rate_info(std::vector<drift_rate> drift_rate_info);
+
+    bland::ndarray integrated_drift_plane();
+    // void set_integrated_drift_plane(bland::ndarray integrated_drifts);
+
+    integrated_flags integrated_rfi();
+
+    void set_device(bland::ndarray::dev dev);
+
+    void set_device(std::string_view dev_str);
+
+    private:
     // slow-time steps passed through for a complete integration, the total number
     // of bins contributing to this integration is demsear_bins * integration_steps
     int64_t _integration_steps;
@@ -34,6 +48,7 @@ struct frequency_drift_plane {
 
     integrated_flags _dedrifted_rfi;
 
+    bland::ndarray::dev _device;
 };
 
 } // namespace bliss

--- a/bliss/core/include/core/integrate_drifts_options.hpp
+++ b/bliss/core/include/core/integrate_drifts_options.hpp
@@ -29,12 +29,30 @@ struct integrated_flags {
     bland::ndarray high_spectral_kurtosis;
     bland::ndarray magnitude;
     bland::ndarray sigma_clip;
+    bland::ndarray::dev _device = default_device;
+
     integrated_flags(int64_t drifts, int64_t channels, bland::ndarray::dev device = default_device) :
             filter_rolloff(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device)),
             low_spectral_kurtosis(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device)),
-            high_spectral_kurtosis(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device)),
-            magnitude(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device)),
-            sigma_clip(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device)) {}
+            high_spectral_kurtosis(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device))
+            // magnitude(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device)),
+            // sigma_clip(bland::ndarray({drifts, channels}, 0, bland::ndarray::datatype::uint8, device))
+            {}
+
+    void set_device(bland::ndarray::dev device) {
+        _device = device;
+        filter_rolloff = filter_rolloff.to(device);
+        low_spectral_kurtosis = low_spectral_kurtosis.to(device);
+        high_spectral_kurtosis = high_spectral_kurtosis.to(device);
+        // magnitude = magnitude.to(device);
+        // sigma_clip = sigma_clip.to(device);
+    }
+
+    void set_device(std::string_view device) {
+        bland::ndarray::dev dev = device;
+        set_device(dev);
+    }
+
 };
 
 } // namespace bliss

--- a/bliss/core/include/core/pyblisscore.hpp
+++ b/bliss/core/include/core/pyblisscore.hpp
@@ -22,63 +22,78 @@ using namespace nb::literals;
 
 void bind_pycore(nb::module_ m) {
 
-    nb::class_<bliss::frequency_drift_plane>(m, "frequency_drift_plane")
-        .def_ro("integrated_drifts", &bliss::frequency_drift_plane::_integrated_drifts)
-    ;
+    nb::class_<bliss::frequency_drift_plane> pyfrequency_drift_plane(m, "frequency_drift_plane");
+    pyfrequency_drift_plane
+        .def("set_device", nb::overload_cast<std::string_view>(&bliss::frequency_drift_plane::set_device))
+        .def_prop_ro("integrated_drifts", &bliss::frequency_drift_plane::integrated_drift_plane)
+        .def_prop_ro("integrated_rfi", &bliss::frequency_drift_plane::integrated_rfi)
+        .def("drift_rate_info", &bliss::frequency_drift_plane::drift_rate_info);
+
+    nb::class_<bliss::frequency_drift_plane::drift_rate>(pyfrequency_drift_plane, "drift_rate")
+        .def_ro("desmeared_bins", &bliss::frequency_drift_plane::drift_rate::desmeared_bins)
+        .def_ro("drift_rate_Hz_per_sec", &bliss::frequency_drift_plane::drift_rate::drift_rate_Hz_per_sec)
+        .def_ro("drift_rate_slope", &bliss::frequency_drift_plane::drift_rate::drift_rate_slope)
+        .def_ro("index_in_plane", &bliss::frequency_drift_plane::drift_rate::index_in_plane);
 
     nb::class_<bliss::coarse_channel>(m, "coarse_channel")
-            .def_ro("data", &bliss::coarse_channel::_data)
-            .def_ro("mask", &bliss::coarse_channel::_mask)
-            .def_ro("hits", &bliss::coarse_channel::_hits)
-            .def_ro("az_start", &bliss::coarse_channel::_az_start)
-            .def_ro("data_type", &bliss::coarse_channel::_data_type)
-            .def_ro("fch1", &bliss::coarse_channel::_fch1)
-            .def_ro("foff", &bliss::coarse_channel::_foff)
-            .def_ro("machine_id", &bliss::coarse_channel::_machine_id)
-            .def_ro("nbits", &bliss::coarse_channel::_nbits)
-            .def_ro("nchans", &bliss::coarse_channel::_nchans)
-            .def_ro("source_name", &bliss::coarse_channel::_source_name)
-            .def_ro("src_dej", &bliss::coarse_channel::_src_dej)
-            .def_ro("src_raj", &bliss::coarse_channel::_src_raj)
-            .def_ro("telescope_id", &bliss::coarse_channel::_telescope_id)
-            .def_ro("tsamp", &bliss::coarse_channel::_tsamp)
-            .def_ro("tstart", &bliss::coarse_channel::_tstart)
-            .def_ro("za_start", &bliss::coarse_channel::_za_start)
-            .def_ro("noise_estimate", &bliss::coarse_channel::_noise_stats)
-            .def("integrated_drift_plane", &bliss::coarse_channel::integrated_drift_plane)
-            .def_prop_rw("device", &bliss::coarse_channel::device, &bliss::coarse_channel::set_device);
+        .def_prop_ro("data", &bliss::coarse_channel::data)
+        .def_prop_ro("mask", &bliss::coarse_channel::mask)
+        .def_prop_ro("hits", &bliss::coarse_channel::hits)
+        .def_prop_ro("az_start", &bliss::coarse_channel::az_start)
+        .def_prop_ro("data_type", &bliss::coarse_channel::data_type)
+        .def_prop_ro("fch1", &bliss::coarse_channel::fch1)
+        .def_prop_ro("foff", &bliss::coarse_channel::foff)
+        .def_prop_ro("machine_id", &bliss::coarse_channel::machine_id)
+        .def_prop_ro("nbits", &bliss::coarse_channel::nbits)
+        .def_prop_ro("nchans", &bliss::coarse_channel::nchans)
+        .def_prop_ro("source_name", &bliss::coarse_channel::source_name)
+        .def_prop_ro("src_dej", &bliss::coarse_channel::src_dej)
+        .def_prop_ro("src_raj", &bliss::coarse_channel::src_raj)
+        .def_prop_ro("telescope_id", &bliss::coarse_channel::telescope_id)
+        .def_prop_ro("tsamp", &bliss::coarse_channel::tsamp)
+        .def_prop_ro("tstart", &bliss::coarse_channel::tstart)
+        .def_prop_ro("za_start", &bliss::coarse_channel::za_start)
+        .def_prop_ro("noise_estimate", &bliss::coarse_channel::noise_estimate)
+        .def("integrated_drift_plane", &bliss::coarse_channel::integrated_drift_plane)
+        .def("device", &bliss::coarse_channel::device)
+        .def("set_device", nb::overload_cast<bland::ndarray::dev&>(&bliss::coarse_channel::set_device))
+        .def("set_device", nb::overload_cast<std::string_view>(&bliss::coarse_channel::set_device));
+
 
     nb::class_<bliss::scan>(m, "scan")
-            .def(nb::init<std::string_view>(), "file_path"_a)
-            .def("get_coarse_channel", &bliss::scan::get_coarse_channel)
-            .def("get_channelization", &bliss::scan::get_channelization)
-            .def("get_coarse_channel_with_frequency", &bliss::scan::get_coarse_channel_with_frequency, "frequency"_a)
-            .def("slice_scan_channels", &bliss::scan::slice_scan_channels, "start"_a=0, "count"_a=1)
-            .def("hits", &bliss::scan::hits)
-            .def_prop_ro("num_coarse_channels", &bliss::scan::get_number_coarse_channels)
-            .def_prop_ro("az_start", &bliss::scan::az_start)
-            .def_prop_ro("data_type",&bliss::scan::data_type)
-            .def_prop_ro("fch1", &bliss::scan::fch1)
-            .def_prop_ro("foff", &bliss::scan::foff)
-            .def_prop_ro("machine_id", &bliss::scan::machine_id)
-            .def_prop_ro("nbits", &bliss::scan::nbits)
-            .def_prop_ro("nchans", &bliss::scan::nchans)
-            .def_prop_ro("source_name", &bliss::scan::source_name)
-            .def_prop_ro("src_dej", &bliss::scan::src_dej)
-            .def_prop_ro("src_raj", &bliss::scan::src_raj)
-            .def_prop_ro("telescope_id", &bliss::scan::telescope_id)
-            .def_prop_ro("tsamp", &bliss::scan::tsamp)
-            .def_prop_ro("tstart", &bliss::scan::tstart)
-            .def_prop_ro("za_start", &bliss::scan::za_start)
-            .def_prop_rw("device", &bliss::scan::device,
-                                   [](bliss::scan &t, std::variant<int, std::string_view> value) {
-                                       if (std::holds_alternative<std::string_view>(value)) {
-                                            t.set_device(std::get<std::string_view>(value));
-                                       } else if (std::holds_alternative<int>(value)) {
-                                            // TODO: handle the case its actually a dev object
-                                            //t.set_device(std::get<bland::ndarray::dev>(value));
-                                       }
-                                   });
+        .def(nb::init<std::string_view>(), "file_path"_a)
+        .def("get_coarse_channel", &bliss::scan::get_coarse_channel)
+        .def("get_channelization", &bliss::scan::get_channelization)
+        .def("get_coarse_channel_with_frequency", &bliss::scan::get_coarse_channel_with_frequency, "frequency"_a)
+        .def("slice_scan_channels", &bliss::scan::slice_scan_channels, "start"_a=0, "count"_a=1)
+        .def("hits", &bliss::scan::hits)
+        .def_prop_ro("num_coarse_channels", &bliss::scan::get_number_coarse_channels)
+        .def_prop_ro("az_start", &bliss::scan::az_start)
+        .def_prop_ro("data_type",&bliss::scan::data_type)
+        .def_prop_ro("fch1", &bliss::scan::fch1)
+        .def_prop_ro("foff", &bliss::scan::foff)
+        .def_prop_ro("machine_id", &bliss::scan::machine_id)
+        .def_prop_ro("nbits", &bliss::scan::nbits)
+        .def_prop_ro("nchans", &bliss::scan::nchans)
+        .def_prop_ro("source_name", &bliss::scan::source_name)
+        .def_prop_ro("src_dej", &bliss::scan::src_dej)
+        .def_prop_ro("src_raj", &bliss::scan::src_raj)
+        .def_prop_ro("telescope_id", &bliss::scan::telescope_id)
+        .def_prop_ro("tsamp", &bliss::scan::tsamp)
+        .def_prop_ro("tstart", &bliss::scan::tstart)
+        .def_prop_ro("za_start", &bliss::scan::za_start)
+        .def("device", &bliss::scan::device)
+        .def("set_device", nb::overload_cast<bland::ndarray::dev&>(&bliss::scan::set_device))
+        .def("set_device", nb::overload_cast<std::string_view>(&bliss::scan::set_device));
+        //     .def_prop_rw("device", &bliss::scan::device,
+        //                            [](bliss::scan &t, std::variant<int, std::string_view> value) {
+        //                                if (std::holds_alternative<std::string_view>(value)) {
+        //                                     t.set_device(std::get<std::string_view>(value));
+        //                                } else if (std::holds_alternative<int>(value)) {
+        //                                     // TODO: handle the case its actually a dev object
+        //                                     //t.set_device(std::get<bland::ndarray::dev>(value));
+        //                                }
+        //                            });
 
     //  * *DIMENSION_LABELS
     //  * *az_start
@@ -98,31 +113,31 @@ void bind_pycore(nb::module_ m) {
     //  * *za_start
 
     nb::class_<bliss::integrate_drifts_options>(m, "integrate_drifts_options")
-            .def(nb::init<>())
-            // .def(nb::init<bool>(), )
-            .def_rw("desmear", &bliss::integrate_drifts_options::desmear)
-            .def_rw("low_rate", &bliss::integrate_drifts_options::low_rate)
-            .def_rw("high_rate", &bliss::integrate_drifts_options::high_rate)
-            .def_rw("rate_step_size", &bliss::integrate_drifts_options::rate_step_size);
+        .def(nb::init<>())
+        // .def(nb::init<bool>(), )
+        .def_rw("desmear", &bliss::integrate_drifts_options::desmear)
+        .def_rw("low_rate", &bliss::integrate_drifts_options::low_rate)
+        .def_rw("high_rate", &bliss::integrate_drifts_options::high_rate)
+        .def_rw("rate_step_size", &bliss::integrate_drifts_options::rate_step_size);
 
     nb::class_<bliss::integrated_flags>(m, "integrated_flags")
-            .def(nb::init<int64_t /*drifts*/, int64_t /*channels*/, bland::ndarray::dev /*device*/>())
-            .def_rw("filter_rolloff", &bliss::integrated_flags::filter_rolloff)
-            .def_rw("low_spectral_kurtosis", &bliss::integrated_flags::low_spectral_kurtosis)
-            .def_rw("high_spectral_kurtosis", &bliss::integrated_flags::high_spectral_kurtosis)
-            .def_rw("magnitude", &bliss::integrated_flags::magnitude)
-            .def_rw("sigma_clip", &bliss::integrated_flags::sigma_clip);
+        .def(nb::init<int64_t /*drifts*/, int64_t /*channels*/, bland::ndarray::dev /*device*/>())
+        .def_rw("filter_rolloff", &bliss::integrated_flags::filter_rolloff)
+        .def_rw("low_spectral_kurtosis", &bliss::integrated_flags::low_spectral_kurtosis)
+        .def_rw("high_spectral_kurtosis", &bliss::integrated_flags::high_spectral_kurtosis)
+        .def_rw("magnitude", &bliss::integrated_flags::magnitude)
+        .def_rw("sigma_clip", &bliss::integrated_flags::sigma_clip);
 
     nb::class_<bliss::observation_target>(m, "observation_target")
-            .def(nb::init<std::vector<bliss::scan>>())
-            .def(nb::init<std::vector<std::string_view>>())
-            .def_rw("scans", &bliss::observation_target::_scans)
-            .def("slice_observation_channels", &bliss::observation_target::slice_observation_channels, "start"_a=0, "count"_a=1)
-            .def_rw("target_name", &bliss::observation_target::_target_name);
+        .def(nb::init<std::vector<bliss::scan>>())
+        .def(nb::init<std::vector<std::string_view>>())
+        .def_rw("scans", &bliss::observation_target::_scans)
+        .def("slice_observation_channels", &bliss::observation_target::slice_observation_channels, "start"_a=0, "count"_a=1)
+        .def_rw("target_name", &bliss::observation_target::_target_name);
 
     nb::class_<bliss::cadence>(m, "cadence")
-            .def(nb::init<std::vector<bliss::observation_target>>())
-            .def(nb::init<std::vector<std::vector<std::string_view>>>())
-            .def("slice_cadence_channels", &bliss::cadence::slice_cadence_channels, "start"_a=0, "count"_a=1)
-            .def_rw("observations", &bliss::cadence::_observations);
+        .def(nb::init<std::vector<bliss::observation_target>>())
+        .def(nb::init<std::vector<std::vector<std::string_view>>>())
+        .def("slice_cadence_channels", &bliss::cadence::slice_cadence_channels, "start"_a=0, "count"_a=1)
+        .def_rw("observations", &bliss::cadence::_observations);
 }

--- a/bliss/core/scan.cpp
+++ b/bliss/core/scan.cpp
@@ -270,7 +270,7 @@ std::list<hit> bliss::scan::hits() {
             auto this_channel_hits = cc->hits();
             all_hits.insert(all_hits.end(), this_channel_hits.cbegin(), this_channel_hits.cend());
         } catch (const std::bad_optional_access &e) {
-            fmt::print("no hits available from coarse channel {}\n", cc_index);
+            fmt::print("WARN: no hits available from coarse channel {}\n", cc_index);
             // TODO: catch specific exception we know might be thrown
         }
     }
@@ -284,12 +284,14 @@ bland::ndarray::dev bliss::scan::device() {
 
 void bliss::scan::set_device(bland::ndarray::dev &device) {
     _device = device;
-    // TODO: what to do about data already in our "cache"?
+    for (auto &[channel_index, cc] : _coarse_channels) {
+        cc->set_device(device);
+    }
 }
 
-void bliss::scan::set_device(std::string_view device) {
-    _device = device;
-    // TODO: what to do about data already in our "cache"?
+void bliss::scan::set_device(std::string_view dev_str) {
+    bland::ndarray::dev device = dev_str;
+    set_device(device);
 }
 
 bliss::scan bliss::scan::slice_scan_channels(int start_channel, int count) {

--- a/bliss/drift_search/CMakeLists.txt
+++ b/bliss/drift_search/CMakeLists.txt
@@ -13,6 +13,13 @@ target_link_libraries(drift_search_kernels
     fmt::fmt-header-only
 )
 
+if (WITH_CUDA)
+    target_link_libraries(drift_search_kernels
+        PRIVATE
+        CUDA::cudart_static
+    )
+endif()
+
 set_target_properties(drift_search_kernels PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 
 

--- a/bliss/drift_search/connected_components.cpp
+++ b/bliss/drift_search/connected_components.cpp
@@ -125,12 +125,12 @@ std::vector<component> bliss::find_components_above_threshold(coarse_channel    
     }
 
     auto drift_plane = dedrifted_coarse_channel.integrated_drift_plane();
-    auto integration_length = drift_plane._integration_steps;
-    auto noise_and_thresholds_per_drift = compute_noise_and_snr_thresholds(noise_stats, integration_length, drift_plane._drift_rate_info, snr_threshold);
+    auto integration_length = drift_plane.integration_steps();
+    auto noise_and_thresholds_per_drift = compute_noise_and_snr_thresholds(noise_stats, integration_length, drift_plane.drift_rate_info(), snr_threshold);
 
     std::vector<component> components;
 
-    auto doppler_spectrum = drift_plane._integrated_drifts;
+    auto doppler_spectrum = drift_plane.integrated_drift_plane();
     if (doppler_spectrum.dtype() != bland::ndarray::datatype::float32) {
         throw std::runtime_error("find_components_above_threshold: dedrifted doppler spectrum was not float. Only cpu "
                                  "float is supported right now");
@@ -189,16 +189,18 @@ std::vector<component> bliss::find_components_above_threshold(coarse_channel    
                         this_component.desmeared_noise = noise_and_thresholds_per_drift[curr_coord[0]].second;
 
                         this_component.index_max       = idx;
+                        auto dedrifted_rfi = drift_plane.integrated_rfi();
+
                         this_component.rfi_counts[flag_values::low_spectral_kurtosis] =
-                                drift_plane._dedrifted_rfi.low_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
+                                dedrifted_rfi.low_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
                         this_component.rfi_counts[flag_values::high_spectral_kurtosis] =
-                                drift_plane._dedrifted_rfi.high_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
+                                dedrifted_rfi.high_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
                         this_component.rfi_counts[flag_values::filter_rolloff] =
-                                drift_plane._dedrifted_rfi.filter_rolloff.scalarize<uint8_t>(curr_coord);
-                        this_component.rfi_counts[flag_values::magnitude] =
-                                drift_plane._dedrifted_rfi.magnitude.scalarize<uint8_t>(curr_coord);
-                        this_component.rfi_counts[flag_values::sigma_clip] =
-                                drift_plane._dedrifted_rfi.sigma_clip.scalarize<uint8_t>(curr_coord);
+                                dedrifted_rfi.filter_rolloff.scalarize<uint8_t>(curr_coord);
+                        // this_component.rfi_counts[flag_values::magnitude] =
+                        //         dedrifted_rfi.magnitude.scalarize<uint8_t>(curr_coord);
+                        // this_component.rfi_counts[flag_values::sigma_clip] =
+                        //         dedrifted_rfi.sigma_clip.scalarize<uint8_t>(curr_coord);
                     }
                     // Then add all of the neighbors as candidates
                     for (auto &neighbor_offset : neighborhood) {

--- a/bliss/drift_search/hit_search.cpp
+++ b/bliss/drift_search/hit_search.cpp
@@ -67,7 +67,8 @@ std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_optio
     }
     auto noise_stats        = dedrifted_scan.noise_estimate();
     auto dedrifted_plane    = dedrifted_scan.integrated_drift_plane();
-    auto integration_length = dedrifted_plane._integration_steps;
+    auto drift_rate_info    = dedrifted_plane.drift_rate_info();
+    auto integration_length = dedrifted_plane.integration_steps();
 
     // Do we need a "component to hit" for each type of search?
     for (const auto &c : components) {
@@ -81,8 +82,8 @@ std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_optio
         auto freq_offset        = dedrifted_scan.foff() * this_hit.start_freq_index;
         this_hit.start_freq_MHz = dedrifted_scan.fch1() + freq_offset;
 
-        this_hit.drift_rate_Hz_per_sec = dedrifted_plane._drift_rate_info[this_hit.rate_index].drift_rate_slope *
-                                         dedrifted_scan.foff() * 1e6 / dedrifted_scan.tsamp();
+        this_hit.drift_rate_Hz_per_sec = drift_rate_info[this_hit.rate_index].drift_rate_slope * dedrifted_scan.foff() *
+                                         1e6 / dedrifted_scan.tsamp();
 
         auto signal_power = (c.max_integration - noise_stats.noise_floor());
 

--- a/bliss/drift_search/kernels/drift_integration_bland.cpp
+++ b/bliss/drift_search/kernels/drift_integration_bland.cpp
@@ -10,6 +10,7 @@
 
 #include <cmath> // std::round, std::abs
 
+
 using namespace bliss;
 
 /**
@@ -24,7 +25,6 @@ using namespace bliss;
  */
 
 constexpr bool collect_rfi = true;
-// template <bool collect_rfi>
 [[nodiscard]] frequency_drift_plane
 bliss::integrate_linear_rounded_bins_bland(const bland::ndarray &spectrum_grid,
                                      const bland::ndarray       &rfi_mask,
@@ -240,5 +240,5 @@ bland::ndarray bliss::integrate_linear_rounded_bins_bland(const bland::ndarray  
                                                     integrate_drifts_options options) {
     auto dummy_rfi_mask                      = bland::ndarray({1, 1});
     auto drift_plane = integrate_linear_rounded_bins_bland(spectrum_grid, dummy_rfi_mask, options);
-    return drift_plane._integrated_drifts;
+    return drift_plane.integrated_drift_plane();
 }

--- a/bliss/drift_search/kernels/drift_integration_cpu.cpp
+++ b/bliss/drift_search/kernels/drift_integration_cpu.cpp
@@ -182,5 +182,5 @@ bland::ndarray bliss::integrate_linear_rounded_bins_cpu(const bland::ndarray    
                                                         integrate_drifts_options options) {
     auto dummy_rfi_mask = bland::ndarray({1, 1});
     auto drift_plane = integrate_linear_rounded_bins_cpu(spectrum_grid, dummy_rfi_mask, options);
-    return drift_plane._integrated_drifts;
+    return drift_plane.integrated_drift_plane();
 }

--- a/bliss/drift_search/local_maxima.cpp
+++ b/bliss/drift_search/local_maxima.cpp
@@ -33,13 +33,13 @@ std::vector<component> bliss::find_local_maxima_above_threshold(coarse_channel  
     auto noise_stats = dedrifted_coarse_channel.noise_estimate();
     
     auto drift_plane = dedrifted_coarse_channel.integrated_drift_plane();
-    auto integration_length = drift_plane._integration_steps;
+    auto integration_length = drift_plane.integration_steps();
 
-    const auto noise_and_thresholds_per_drift = compute_noise_and_snr_thresholds(noise_stats, integration_length, drift_plane._drift_rate_info, snr_threshold);
+    const auto noise_and_thresholds_per_drift = compute_noise_and_snr_thresholds(noise_stats, integration_length, drift_plane.drift_rate_info(), snr_threshold);
 
     std::vector<component> maxima;
     
-    auto doppler_spectrum = drift_plane._integrated_drifts;
+    auto doppler_spectrum = drift_plane.integrated_drift_plane();
     if (doppler_spectrum.dtype() != bland::ndarray::datatype::float32) {
         throw std::runtime_error(
                 "find_local_maxima_above_threshold: dedrifted doppler spectrum was not float. Only cpu "
@@ -114,16 +114,18 @@ std::vector<component> bliss::find_local_maxima_above_threshold(coarse_channel  
                     c.max_integration = candidate_maxima_val;
                     c.desmeared_noise = noise_and_thresholds_per_drift[curr_coord[0]].second;
 
+                    auto dedrifted_rfi = drift_plane.integrated_rfi();
+
                     c.rfi_counts[flag_values::low_spectral_kurtosis] =
-                            drift_plane._dedrifted_rfi.low_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
+                            dedrifted_rfi.low_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
                     c.rfi_counts[flag_values::high_spectral_kurtosis] =
-                            drift_plane._dedrifted_rfi.high_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
+                            dedrifted_rfi.high_spectral_kurtosis.scalarize<uint8_t>(curr_coord);
                     c.rfi_counts[flag_values::filter_rolloff] =
-                            drift_plane._dedrifted_rfi.filter_rolloff.scalarize<uint8_t>(curr_coord);
-                    c.rfi_counts[flag_values::magnitude] =
-                            drift_plane._dedrifted_rfi.magnitude.scalarize<uint8_t>(curr_coord);
-                    c.rfi_counts[flag_values::sigma_clip] =
-                            drift_plane._dedrifted_rfi.sigma_clip.scalarize<uint8_t>(curr_coord);
+                            dedrifted_rfi.filter_rolloff.scalarize<uint8_t>(curr_coord);
+                    // c.rfi_counts[flag_values::magnitude] =
+                    //         dedrifted_rfi.magnitude.scalarize<uint8_t>(curr_coord);
+                    // c.rfi_counts[flag_values::sigma_clip] =
+                    //         dedrifted_rfi.sigma_clip.scalarize<uint8_t>(curr_coord);
 
                     // Wow, this very conceptually simple thing of adding a bandwidth estimate to local maxima hits
                     // wound up being some ugly code... rethink it


### PR DESCRIPTION
Adds device-awareness to various pipeline objects.

At this point data can be read to cuda buffers, flagging, noise estimation, dedrift integration can be run on gpu, set the device to cpu, run the rest of the pipeline.

It appears that the hits on test files are exact matches to old sets of hits on these files

Closes #18 