### PR TITLE
setup easier API for scanning multiple coarse channels

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,7 +9,6 @@
 name: Build and upload python package
 
 on:
-  push:
   release:
     types: [published]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ endif()
 
 # HDF5
 # set(HDF5_USE_STATIC_LIBRARIES ON)
-find_package(HDF5 QUIET REQUIRED COMPONENTS CXX)
+find_package(HDF5 REQUIRED COMPONENTS CXX)
 set_package_properties(HDF5 PROPERTIES
     URL "https://www.hdfgroup.org/solutions/hdf5/"
     DESCRIPTION "Hierarchical Data Format"

--- a/bliss/core/coarse_channel.cpp
+++ b/bliss/core/coarse_channel.cpp
@@ -4,6 +4,8 @@
 #include "fmt/format.h"
 #include "fmt/ranges.h"
 
+#include <variant>
+
 using namespace bliss;
 
 coarse_channel::coarse_channel(
@@ -132,13 +134,20 @@ bland::ndarray::dev bliss::coarse_channel::device() {
 
 void bliss::coarse_channel::set_device(bland::ndarray::dev &device) {
     _device = device;
-    // if (_integrated_drift_plane.has_value()) {
-    //     _integrated_drift_plane.value().set_device(_device);
-    // }
 }
 
 void bliss::coarse_channel::set_device(std::string_view device) {
     _device = device;
+}
+
+void bliss::coarse_channel::push_device() {
+    _mask = _mask.to(_device);
+    _data = _mask.to(_device);
+    if (std::holds_alternative<frequency_drift_plane>(*_integrated_drift_plane)) {
+        auto idp = std::get<frequency_drift_plane>(*_integrated_drift_plane);
+        idp.set_device(_device);
+        idp.push_device();
+    }
 }
 
 double bliss::coarse_channel::fch1() const {

--- a/bliss/core/frequency_drift_plane.cpp
+++ b/bliss/core/frequency_drift_plane.cpp
@@ -19,21 +19,29 @@ std::vector<bliss::frequency_drift_plane::drift_rate> bliss::frequency_drift_pla
 }
 
 bland::ndarray bliss::frequency_drift_plane::integrated_drift_plane() {
+    _integrated_drifts = _integrated_drifts.to(_device);
     return _integrated_drifts;
 }
 
 integrated_flags bliss::frequency_drift_plane::integrated_rfi() {
+    _dedrifted_rfi.set_device(_device);
+    _dedrifted_rfi.push_device();
     return _dedrifted_rfi;
 }
 
 void bliss::frequency_drift_plane::set_device(bland::ndarray::dev dev) {
     _device = dev;
-    _dedrifted_rfi.set_device(_device);
-    _integrated_drifts = _integrated_drifts.to(_device);
 }
 
 void bliss::frequency_drift_plane::set_device(std::string_view dev_str) {
     auto dev = bland::ndarray::dev(dev_str);
     set_device(dev);
 }
+
+void bliss::frequency_drift_plane::push_device() {
+    _dedrifted_rfi.set_device(_device);
+    _dedrifted_rfi.push_device();
+    _integrated_drifts = _integrated_drifts.to(_device);
+}
+
 

--- a/bliss/core/include/core/coarse_channel.hpp
+++ b/bliss/core/include/core/coarse_channel.hpp
@@ -98,6 +98,8 @@ struct coarse_channel {
     void set_device(bland::ndarray::dev &device);
     void set_device(std::string_view device);
 
+    void push_device();
+
     double fch1() const;
     // void        fch1(double);
     double foff() const;

--- a/bliss/core/include/core/frequency_drift_plane.hpp
+++ b/bliss/core/include/core/frequency_drift_plane.hpp
@@ -36,6 +36,8 @@ class frequency_drift_plane {
 
     void set_device(std::string_view dev_str);
 
+    void push_device();
+
     private:
     // slow-time steps passed through for a complete integration, the total number
     // of bins contributing to this integration is demsear_bins * integration_steps

--- a/bliss/core/include/core/integrate_drifts_options.hpp
+++ b/bliss/core/include/core/integrate_drifts_options.hpp
@@ -41,16 +41,19 @@ struct integrated_flags {
 
     void set_device(bland::ndarray::dev device) {
         _device = device;
-        filter_rolloff = filter_rolloff.to(device);
-        low_spectral_kurtosis = low_spectral_kurtosis.to(device);
-        high_spectral_kurtosis = high_spectral_kurtosis.to(device);
-        // magnitude = magnitude.to(device);
-        // sigma_clip = sigma_clip.to(device);
     }
 
     void set_device(std::string_view device) {
         bland::ndarray::dev dev = device;
         set_device(dev);
+    }
+
+    void push_device() {
+        filter_rolloff = filter_rolloff.to(_device);
+        low_spectral_kurtosis = low_spectral_kurtosis.to(_device);
+        high_spectral_kurtosis = high_spectral_kurtosis.to(_device);
+        // magnitude = magnitude.to(device);
+        // sigma_clip = sigma_clip.to(device);
     }
 
 };

--- a/bliss/core/include/core/pyblisscore.hpp
+++ b/bliss/core/include/core/pyblisscore.hpp
@@ -25,6 +25,7 @@ void bind_pycore(nb::module_ m) {
     nb::class_<bliss::frequency_drift_plane> pyfrequency_drift_plane(m, "frequency_drift_plane");
     pyfrequency_drift_plane
         .def("set_device", nb::overload_cast<std::string_view>(&bliss::frequency_drift_plane::set_device))
+        .def("push_device", (&bliss::frequency_drift_plane::push_device))
         .def_prop_ro("integrated_drifts", &bliss::frequency_drift_plane::integrated_drift_plane)
         .def_prop_ro("integrated_rfi", &bliss::frequency_drift_plane::integrated_rfi)
         .def("drift_rate_info", &bliss::frequency_drift_plane::drift_rate_info);
@@ -57,12 +58,14 @@ void bind_pycore(nb::module_ m) {
         .def("integrated_drift_plane", &bliss::coarse_channel::integrated_drift_plane)
         .def("device", &bliss::coarse_channel::device)
         .def("set_device", nb::overload_cast<bland::ndarray::dev&>(&bliss::coarse_channel::set_device))
-        .def("set_device", nb::overload_cast<std::string_view>(&bliss::coarse_channel::set_device));
+        .def("set_device", nb::overload_cast<std::string_view>(&bliss::coarse_channel::set_device))
+        .def("push_device", (&bliss::coarse_channel::push_device));
 
 
     nb::class_<bliss::scan>(m, "scan")
         .def(nb::init<std::string_view>(), "file_path"_a)
-        .def("get_coarse_channel", &bliss::scan::get_coarse_channel)
+        .def("read_coarse_channel", &bliss::scan::read_coarse_channel)
+        .def("peak_coarse_channel", &bliss::scan::peak_coarse_channel)
         .def("get_channelization", &bliss::scan::get_channelization)
         .def("get_coarse_channel_with_frequency", &bliss::scan::get_coarse_channel_with_frequency, "frequency"_a)
         .def("slice_scan_channels", &bliss::scan::slice_scan_channels, "start"_a=0, "count"_a=1)
@@ -84,7 +87,8 @@ void bind_pycore(nb::module_ m) {
         .def_prop_ro("za_start", &bliss::scan::za_start)
         .def("device", &bliss::scan::device)
         .def("set_device", nb::overload_cast<bland::ndarray::dev&>(&bliss::scan::set_device))
-        .def("set_device", nb::overload_cast<std::string_view>(&bliss::scan::set_device));
+        .def("set_device", nb::overload_cast<std::string_view>(&bliss::scan::set_device))
+        .def("push_device", (&bliss::scan::push_device));
         //     .def_prop_rw("device", &bliss::scan::device,
         //                            [](bliss::scan &t, std::variant<int, std::string_view> value) {
         //                                if (std::holds_alternative<std::string_view>(value)) {

--- a/bliss/drift_search/hit_search.cpp
+++ b/bliss/drift_search/hit_search.cpp
@@ -59,7 +59,9 @@ bland::ndarray bliss::hard_threshold_drifts(const bland::ndarray &dedrifted_spec
 std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_options options) {
     // We have to be on cpu for now
     dedrifted_scan.set_device("cpu");
+    dedrifted_scan.push_device();
     std::list<hit> hits;
+    fmt::print("Pushed device for dedrifted scan\n");
 
     std::vector<component> components;
     if (options.method == hit_search_methods::CONNECTED_COMPONENTS) {
@@ -131,7 +133,7 @@ std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_optio
 scan bliss::hit_search(scan dedrifted_scan, hit_search_options options) {
     auto number_coarse_channels = dedrifted_scan.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc   = dedrifted_scan.get_coarse_channel(cc_index);
+        auto cc   = dedrifted_scan.read_coarse_channel(cc_index);
         auto hits = hit_search(*cc, options);
         cc->add_hits(hits);
     }

--- a/bliss/drift_search/integrate_drifts.cpp
+++ b/bliss/drift_search/integrate_drifts.cpp
@@ -55,7 +55,7 @@ coarse_channel bliss::integrate_drifts(coarse_channel cc_data, integrate_drifts_
 scan bliss::integrate_drifts(scan scan_data, integrate_drifts_options options) {
     auto number_coarse_channels = scan_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc = scan_data.get_coarse_channel(cc_index);
+        auto cc = scan_data.read_coarse_channel(cc_index);
         *cc = integrate_drifts(*cc, options);
     }
     return scan_data;

--- a/bliss/drift_search/local_maxima.cpp
+++ b/bliss/drift_search/local_maxima.cpp
@@ -49,6 +49,9 @@ std::vector<component> bliss::find_local_maxima_above_threshold(coarse_channel  
     auto          doppler_spectrum_strides = doppler_spectrum.strides();
     stride_helper doppler_spectrum_strider(doppler_spectrum.shape(), doppler_spectrum_strides);
 
+    fmt::print("doppler_spectrum is on device {}\n", doppler_spectrum.device().repr());
+
+
     // Use 1 to mark visited, then we can potentially replace this creation with a mask of above thresh to speed things
     // up a bit
     auto visited = bland::ndarray(doppler_spectrum.shape(),

--- a/bliss/estimators/noise_estimate.cpp
+++ b/bliss/estimators/noise_estimate.cpp
@@ -192,7 +192,7 @@ noise_stats bliss::estimate_noise_power(coarse_channel cc_data, noise_power_esti
 scan bliss::estimate_noise_power(scan fil_data, noise_power_estimate_options options) {
     auto number_coarse_channels = fil_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc = fil_data.get_coarse_channel(cc_index);
+        auto cc = fil_data.read_coarse_channel(cc_index);
         auto cc_noise_estimate = estimate_noise_power(*cc, options);
         cc->set_noise_estimate(cc_noise_estimate);
     }

--- a/bliss/flaggers/filter_rolloff.cpp
+++ b/bliss/flaggers/filter_rolloff.cpp
@@ -29,7 +29,7 @@ coarse_channel bliss::flag_filter_rolloff(coarse_channel cc_data, float rolloff_
 scan bliss::flag_filter_rolloff(scan fil_data, float rolloff_width) {
     auto number_coarse_channels = fil_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc = fil_data.get_coarse_channel(cc_index);
+        auto cc = fil_data.read_coarse_channel(cc_index);
         *cc = flag_filter_rolloff(*cc, rolloff_width);
     }
     return fil_data;

--- a/bliss/flaggers/magnitude.cpp
+++ b/bliss/flaggers/magnitude.cpp
@@ -40,7 +40,7 @@ coarse_channel bliss::flag_magnitude(coarse_channel cc_data) {
 scan bliss::flag_magnitude(scan fil_data, float threshold) {
     auto number_coarse_channels = fil_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc = fil_data.get_coarse_channel(cc_index);
+        auto cc = fil_data.read_coarse_channel(cc_index);
         *cc = flag_magnitude(*cc, threshold);
     }
     return fil_data;
@@ -49,7 +49,7 @@ scan bliss::flag_magnitude(scan fil_data, float threshold) {
 scan bliss::flag_magnitude(scan fil_data) {
     auto number_coarse_channels = fil_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc = fil_data.get_coarse_channel(cc_index);
+        auto cc = fil_data.read_coarse_channel(cc_index);
         *cc = flag_magnitude(*cc);
     }
     return fil_data;

--- a/bliss/flaggers/spectral_kurtosis.cpp
+++ b/bliss/flaggers/spectral_kurtosis.cpp
@@ -57,7 +57,7 @@ coarse_channel bliss::flag_spectral_kurtosis(coarse_channel cc_data, float lower
 scan bliss::flag_spectral_kurtosis(scan fil_data, float lower_threshold, float upper_threshold) {
     auto number_coarse_channels = fil_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        auto cc = fil_data.get_coarse_channel(cc_index);
+        auto cc = fil_data.read_coarse_channel(cc_index);
         *cc = flag_spectral_kurtosis(*cc, lower_threshold, upper_threshold);
     }
     return fil_data;

--- a/bliss/justrun.cpp
+++ b/bliss/justrun.cpp
@@ -21,9 +21,11 @@
 int main(int argc, char **argv) {
 
 
-    // if (argc == 2) {
-    //     fil_path = argv[1];
-    // }
+    std::string fil_path = "/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5";
+    if (argc == 2) {
+        fil_path = argv[1];
+    }
+
 
     // auto mlc4_cadence = bliss::cadence({{"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_08789_HIP54677_0009.gpuspec.0000.h5",
     //                  "/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_09628_HIP54677_0011.gpuspec.0000.h5",
@@ -33,19 +35,19 @@ int main(int argc, char **argv) {
     //                  {"/datag/public/seti_benchmarking/mlc4/spliced_blc0001020304050607_guppi_57517_10836_HIP53839_0014.gpuspec.0000.h5"}});
 
 
-    auto voyager_cadence = bliss::cadence({{"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5",
-                    "/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80672_DIAG_VOYAGER-1_0013.rawspec.0000.h5",
-                    "/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_81310_DIAG_VOYAGER-1_0015.rawspec.0000.h5"
-                    },
-                    {"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"},
-                    {"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80989_DIAG_VOYAGER-1_0014.rawspec.0000.h5"},
-                    {"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_81628_DIAG_VOYAGER-1_0016.rawspec.0000.h5"}});
+    // auto voyager_cadence = bliss::cadence({{"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5",
+    //                 "/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80672_DIAG_VOYAGER-1_0013.rawspec.0000.h5",
+    //                 "/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_81310_DIAG_VOYAGER-1_0015.rawspec.0000.h5"
+    //                 },
+    //                 {"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80354_DIAG_VOYAGER-1_0012.rawspec.0000.h5"},
+    //                 {"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_80989_DIAG_VOYAGER-1_0014.rawspec.0000.h5"},
+    //                 {"/datag/public/voyager_2020/single_coarse_channel/old_single_coarse/single_coarse_guppi_59046_81628_DIAG_VOYAGER-1_0016.rawspec.0000.h5"}});
 
     // auto cadence = voyager_cadence.slice_cadence_channels(188);
-    auto cadence = voyager_cadence;
+    // auto cadence = voyager_cadence;
+    auto cadence = bliss::cadence({{fil_path}});
 
     auto scan = cadence._observations[0]._scans[0];
-//     scan.set_device("cpu");
     scan.set_device("cuda:0");
 
     scan = bliss::flag_filter_rolloff(scan, 0.2);
@@ -55,26 +57,29 @@ int main(int argc, char **argv) {
             scan,
             bliss::noise_power_estimate_options{.estimator_method=bliss::noise_power_estimator::STDDEV, .masked_estimate = true}); // estimate noise power of unflagged data
 
-    fmt::print("{}\n", scan.get_coarse_channel(0)->noise_estimate().repr());
-
     scan = bliss::integrate_drifts(
             scan,
             bliss::integrate_drifts_options{.desmear        = true,
-                                            .low_rate       = -400,
-                                            .high_rate      = 400,
+                                            .low_rate       = -100,
+                                            .high_rate      = 100,
                                             .rate_step_size = 1});
     scan.set_device("cpu");
 
-    auto scan_with_hits = bliss::hit_search(scan, {.method=bliss::hit_search_methods::CONNECTED_COMPONENTS, .snr_threshold=10.0f});
+    auto coarse_channel = scan.read_coarse_channel(0);
+    coarse_channel->integrated_drift_plane();
 
-//     cadence = bliss::integrate_drifts(
-//             cadence,
-//             bliss::integrate_drifts_options{.desmear        = false,
-//                                             .low_rate       = -48,
-//                                             .high_rate      = 48,
-//                                             .rate_step_size = 1});
 
-//     cadence = bliss::hit_search(cadence, {.method=bliss::hit_search_methods::CONNECTED_COMPONENTS, .snr_threshold=10.0f});
+    auto scan_with_hits = bliss::hit_search(scan, {.method=bliss::hit_search_methods::LOCAL_MAXIMA,
+                                                        .snr_threshold=10.0f});
+
+    fmt::print("{}\n", scan.read_coarse_channel(0)->noise_estimate().repr());
+
+    fmt::print("{} hits found\n", scan_with_hits.hits().size());
+    for (auto &hit : scan_with_hits.hits()) {
+        fmt::print("{}\n", hit.repr());
+    }
+
+    // cadence = bliss::hit_search(cadence, {.method=bliss::hit_search_methods::CONNECTED_COMPONENTS, .snr_threshold=10.0f});
 
 //     bliss::write_cadence_hits_to_files(cadence, "hits");
 

--- a/bliss/python/bliss/__init__.py
+++ b/bliss/python/bliss/__init__.py
@@ -6,3 +6,5 @@ __version__ = '0.0.1'
 
 from .pybliss import *
 from . import pybland as bland
+
+from . import plot_utils

--- a/bliss/python/bliss/plot_utils/__init__.py
+++ b/bliss/python/bliss/plot_utils/__init__.py
@@ -1,0 +1,2 @@
+
+from .plot_hits import plot_hits

--- a/bliss/python/bliss/plot_utils/plot_hits.py
+++ b/bliss/python/bliss/plot_utils/plot_hits.py
@@ -1,0 +1,64 @@
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import matplotlib.gridspec as gridspec
+from matplotlib.patches import Rectangle
+
+
+def plot_hits(cc):
+    spectrum = cc.data
+    spectrum = spectrum.to("cpu")
+    plot_spectrum = np.log10(np.from_dlpack(spectrum) + 1e-3)
+    
+    plane = cc.integrated_drift_plane().integrated_drifts
+    plane = plane.to("cpu")
+    plot_plane = np.log10(np.from_dlpack(plane) + 1e-3)
+
+    fch1 = cc.fch1
+    foff = cc.foff
+    nchans = cc.nchans
+    freqs = np.linspace(fch1, fch1 + foff * nchans, nchans)
+
+    start_time = cc.tstart * 24 * 60 * 60
+    end_time = start_time + cc.tsamp * plot_spectrum.shape[0]
+
+
+    # Create a gridspec instance with 10 rows
+    gs = gridspec.GridSpec(20, 1)
+
+    plt.figure()
+
+    # Assign different rows to your subplots
+    ax0 = plt.subplot(gs[:4, 0])  # Top plot gets 1 row (10% of the height)
+    ax1 = plt.subplot(gs[4:12, 0], sharex=ax0)  # Middle plot gets 4 rows (40% of the height)
+    ax2 = plt.subplot(gs[12:, 0], sharex=ax0)  # Bottom plot gets 5 rows (50% of the height)
+
+    # fig, axes = plt.subplots(3, 1, sharex=True, sharey=False, figsize=(10, 10))
+
+    spec_min = np.nanmin(plot_spectrum)
+    spec_max = np.nanmax(plot_spectrum) - 1
+
+    plane_min = np.nanmin(plot_plane) + 7
+    plane_max = np.nanmax(plot_plane) - 1
+
+    ax0.plot(freqs, plot_spectrum.sum(0))
+    ax1.imshow(plot_spectrum, aspect="auto", interpolation="None", cmap="turbo", vmin=spec_min, vmax=spec_max, extent=[freqs[0], freqs[-1], end_time, start_time])
+    ax2.imshow(plot_plane, aspect="auto", interpolation="None", cmap="turbo", vmin=plane_min, vmax=plane_max, extent=[freqs[0], freqs[-1], 100, -100])
+
+    aspect_ratio = get_aspect(ax1)
+
+    for hit in cc.hits:
+        # start_time = plot_scan.tstart * 24 * 60 * 60
+        # end_time = start_time + plot_scan.tsamp * plot_data.shape[0]
+        start_freq = hit.start_freq_MHz
+        end_freq = start_freq + (end_time - start_time) * hit.drift_rate_Hz_per_sec*1e6
+
+        color = "red"
+        # angle=-(end_time-start_time)/(1e-3 + (end_freq-start_freq)*1e6) * aspect_ratio / 45
+        angle = 0
+        # (end_freq-start_freq) + 
+        rect = Rectangle(((start_freq), start_time), hit.bandwidth/1e6, end_time-start_time, edgecolor=color, fill=None, angle=angle, rotation_point="center")
+        ax1.add_patch(rect)
+
+    plt.tight_layout()


### PR DESCRIPTION
Closes #13 

Moves the structure (map) holding coarse channels to a shared_ptr<map> so slices of a scan share the same holder. This means when requesting hits from all coarse_channels from the root scan it will have access to the coarse_channels that have gone through the pipeline.

Also add a peak method for coarse_channels that will only return a valid coarse_channel if it's already in the holder and rename the `get_coarse_channel` method to a now more clear `read_coarse_channel` since that will trigger a read from disk if not already in the map

Also adds minor plot utils to python package