### PR TITLE
Rel cuda

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,6 +43,10 @@ jobs:
       - name: Build wheels for CPython
         run: |
           python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
+          ls dist
+          ls dist/*
+          wheel=$(ls dist/${{ env.CUDA_VER }}/dedrift-*.whl)
+          mv "$wheel" "${wheel/dedrift-/dedrift-${{ env.CUDA_VER }}-}"
         env:
           CIBW_BUILD: "cp*-*64"
           CIBW_SKIP: "*musllinux*"
@@ -58,12 +62,10 @@ jobs:
               export PATH=$PATH:/usr/local/cuda/bin
             fi
 
-      - name: Rename wheel
-        run: |
-          wheel=$(ls dist/${{ env.CUDA_VER }}/dedrift-*.whl)
-          mv "$wheel" "${wheel/dedrift-/dedrift-${{ env.CUDA_VER }}-}"
-        env:
-          CUDA_VER: ${{ matrix.cuda_ver }}
+            #- name: Rename wheel
+            #  run: |
+            #  env:
+            #    CUDA_VER: ${{ matrix.cuda_ver }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -73,16 +73,6 @@ jobs:
         with:
           name: artifact
           path: dist
-	  - name: Rename wheels
-	    run: |
-	      for dir in dist/*; do
-	        cuda_ver=$(basename $dir)
-	        for wheel in $dir/*.whl; do
-	          wheel_name=$(basename $wheel)
-	          new_wheel_name="${wheel_name//dedrift-/dedrift-$cuda_ver-}"
-	          mv "$wheel" "$dir/$new_wheel_name"
-	        done
-	      done
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1.8

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           name: artifact
           path: dist
-
 	  - name: Rename wheels
 	    run: |
 	      for dir in dist/*; do

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,9 +44,11 @@ jobs:
         run: |
           python3 -m cibuildwheel --output-dir dist
         env:
+          CIBW_BUILD: "cp*-*64"
+          CIBW_SKIP: "*musllinux*"
           CUDA_VER: ${{ matrix.cuda_ver }}
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-          CIBW_BEFORE_BUILD: |
+          CIBW_BEFORE_BUILD_LINUX: |
             git submodule update --init --recursive && pip install .
             (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
@@ -56,7 +58,6 @@ jobs:
               export PATH=$PATH:/usr/local/cuda/bin
             fi
             sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/bliss/python/bliss/__init__.py
-          CIBW_SKIP: "*musllinux*"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -48,8 +48,6 @@ jobs:
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: |
             git submodule update --init --recursive && pip install .
-          # Install system library
-          CIBW_BEFORE_BUILD_LINUX: |
             (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
               yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           python3 -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp*-*64+cuda${{ matrix.cuda_ver }}"
+          CUDA_VER: ${{ matrix.cuda_ver }}
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: |
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,17 +11,18 @@ name: Build and upload python package
 on:
   release:
     types: [published]
+  push:
 
 permissions:
   contents: read
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.cuda_ver }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        cuda_ver: ['none', '11.4', '12.4']
 
     steps:
       - uses: actions/checkout@v3
@@ -45,7 +46,14 @@ jobs:
         env:
           CIBW_BUILD: "cp*-*64"
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-          CIBW_BEFORE_BUILD: git submodule update --init --recursive && pip install .
+          CIBW_BEFORE_BUILD: |
+            if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
+              yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
+              yum clean all
+              yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
+              export PATH=$PATH:/usr/local/cuda/bin
+            fi
+            git submodule update --init --recursive && pip install .
           # Install system library
           CIBW_BEFORE_BUILD_LINUX: (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
           CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -47,15 +47,17 @@ jobs:
           CUDA_VER: ${{ matrix.cuda_ver }}
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: |
+            git submodule update --init --recursive && pip install .
+          # Install system library
+          CIBW_BEFORE_BUILD_LINUX: |
+            (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
               yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
               yum clean all
               yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
               export PATH=$PATH:/usr/local/cuda/bin
             fi
-            git submodule update --init --recursive && pip install .
-          # Install system library
-          CIBW_BEFORE_BUILD_LINUX: (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
+            sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/bliss/python/bliss/__init__.py
           CIBW_SKIP: "*musllinux*"
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -50,6 +50,7 @@ jobs:
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD_LINUX: |
             (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
+            python3 -m pip install py-build-cmake~=0.2.0a7 cmake~=3.29.0 ninja~=1.11
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
               yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
               yum clean all

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -45,8 +45,12 @@ jobs:
           python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
           ls dist
           ls dist/*
-          wheel=$(ls dist/${{ env.CUDA_VER }}/dedrift-*.whl)
-          mv "$wheel" "${wheel/dedrift-/dedrift-${{ env.CUDA_VER }}-}"
+          for wheel in dist/${{ env.CUDA_VER }}/dedrift-*.whl; do
+            wheel_name=$(basename "$wheel")
+            new_wheel_name="${wheel_name/-/-${{ env.CUDA_VER }}-}"
+            mv "$wheel" "dist/$new_wheel_name"
+          done
+
         env:
           CIBW_BUILD: "cp*-*64"
           CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build wheels for CPython
         run: |
-          python3 -m cibuildwheel --output-dir dist
+          python3 -m cibuildwheel --output-dir dist/{{ matrix.cuda_ver }}/
         env:
           CIBW_BUILD: "cp*-*64"
           CIBW_SKIP: "*musllinux*"
@@ -57,11 +57,12 @@ jobs:
               yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
               export PATH=$PATH:/usr/local/cuda/bin
             fi
-            sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/bliss/python/bliss/__init__.py
 
       - uses: actions/upload-artifact@v2
         with:
           path: dist
+
+
 
   upload:
     name: Upload to PyPi and create release
@@ -73,10 +74,21 @@ jobs:
           name: artifact
           path: dist
 
+	  - name: Rename wheels
+	    run: |
+	      for dir in dist/*; do
+	        cuda_ver=$(basename $dir)
+	        for wheel in $dir/*.whl; do
+	          wheel_name=$(basename $wheel)
+	          new_wheel_name="${wheel_name//dedrift-/dedrift-$cuda_ver-}"
+	          mv "$wheel" "$dir/$new_wheel_name"
+	        done
+	      done
+
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: True
+          skip-existing: False
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -45,7 +45,7 @@ jobs:
           if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
             sed -i "s/name = \"dedrift\"/name = \"dedrift-cuda${{ matrix.cuda_ver }}\"/g" pyproject.toml
           fi
-          python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
+          python3 -m cibuildwheel --output-dir dist/
         env:
           CIBW_BUILD: "cp*-*64"
           CIBW_SKIP: "*musllinux*"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python3 -m pip install cibuildwheel
+          python3 -m pip install cibuildwheel==2.17.0
 
       - name: Build wheels for CPython
         run: |
@@ -57,7 +57,6 @@ jobs:
               export PATH=$PATH:/usr/local/cuda/bin
             fi
             sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/bliss/python/bliss/__init__.py
-            git submodule update --init --recursive && pip install .
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build wheels for CPython
         run: |
-          python -c "import toml;p = toml.load('pyproject.toml');p['project']['name'] = f\"dedrift-${{ matrix.cuda_ver }}\";toml.dump(p, open('pyproject.toml', 'w'))"
+          sed -i "s/name = \"dedrift\"/name = \"dedrift-${{ matrix.cuda_ver }}\"/g" pyproject.toml
           python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
         env:
           CIBW_BUILD: "cp*-*64"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Build wheels for CPython
         run: |
-          python3 -m cibuildwheel --output-dir dist/{{ matrix.cuda_ver }}/
+          python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
         env:
           CIBW_BUILD: "cp*-*64"
           CIBW_SKIP: "*musllinux*"
@@ -57,6 +57,13 @@ jobs:
               yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
               export PATH=$PATH:/usr/local/cuda/bin
             fi
+
+      - name: Rename wheel
+        run: |
+          wheel=$(ls dist/${{ env.CUDA_VER }}/dedrift-*.whl)
+          mv "$wheel" "${wheel/dedrift-/dedrift-${{ env.CUDA_VER }}-}"
+        env:
+          CUDA_VER: ${{ matrix.cuda_ver }}
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Build wheels for CPython
         run: |
-          sed -i "s/name = \"dedrift\"/name = \"dedrift-${{ matrix.cuda_ver }}\"/g" pyproject.toml
+          if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
+            sed -i "s/name = \"dedrift\"/name = \"dedrift-cuda${{ matrix.cuda_ver }}\"/g" pyproject.toml
+          fi
           python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
         env:
           CIBW_BUILD: "cp*-*64"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.cuda_ver }}
+    name: Build wheels for cuda ${{ matrix.cuda_ver }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,7 +44,7 @@ jobs:
         run: |
           python3 -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp*-*64"
+          CIBW_BUILD: "cp*-*64+cuda${{ matrix.cuda_ver }}"
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: |
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -56,10 +56,7 @@ jobs:
               yum clean all
               yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
               export PATH=$PATH:/usr/local/cuda/bin
-              python -c "import toml; \
-  p = toml.load('pyproject.toml'); \
-  p['project']['name'] = f\"dedrift-${{ matrix.cuda_ver }}\"; \
-  toml.dump(p, open('pyproject.toml', 'w'))"
+              python -c "import toml;p = toml.load('pyproject.toml');p['project']['name'] = f\"dedrift-${{ matrix.cuda_ver }}\";toml.dump(p, open('pyproject.toml', 'w'))"
             fi
             #sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/pyproject.toml
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -49,7 +49,6 @@ jobs:
           CUDA_VER: ${{ matrix.cuda_ver }}
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD_LINUX: |
-            git submodule update --init --recursive && pip install .
             (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
               yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
@@ -58,6 +57,7 @@ jobs:
               export PATH=$PATH:/usr/local/cuda/bin
             fi
             sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/bliss/python/bliss/__init__.py
+            git submodule update --init --recursive && pip install .
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Build wheels for CPython
         run: |
+          python -c "import toml;p = toml.load('pyproject.toml');p['project']['name'] = f\"dedrift-${{ matrix.cuda_ver }}\";toml.dump(p, open('pyproject.toml', 'w'))"
           python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
         env:
           CIBW_BUILD: "cp*-*64"
@@ -56,7 +57,6 @@ jobs:
               yum clean all
               yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
               export PATH=$PATH:/usr/local/cuda/bin
-              python -c "import toml;p = toml.load('pyproject.toml');p['project']['name'] = f\"dedrift-${{ matrix.cuda_ver }}\";toml.dump(p, open('pyproject.toml', 'w'))"
             fi
             #sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/pyproject.toml
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,14 +43,6 @@ jobs:
       - name: Build wheels for CPython
         run: |
           python3 -m cibuildwheel --output-dir dist/${{ env.CUDA_VER }}/
-          ls dist
-          ls dist/*
-          for wheel in dist/${{ env.CUDA_VER }}/dedrift-*.whl; do
-            wheel_name=$(basename "$wheel")
-            new_wheel_name="${wheel_name/-/-${{ env.CUDA_VER }}-}"
-            mv "$wheel" "dist/$new_wheel_name"
-          done
-
         env:
           CIBW_BUILD: "cp*-*64"
           CIBW_SKIP: "*musllinux*"
@@ -64,12 +56,12 @@ jobs:
               yum clean all
               yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
               export PATH=$PATH:/usr/local/cuda/bin
+              python -c "import toml; \
+  p = toml.load('pyproject.toml'); \
+  p['project']['name'] = f\"dedrift-${{ matrix.cuda_ver }}\"; \
+  toml.dump(p, open('pyproject.toml', 'w'))"
             fi
-
-            #- name: Rename wheel
-            #  run: |
-            #  env:
-            #    CUDA_VER: ${{ matrix.cuda_ver }}
+            #sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/pyproject.toml
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -11,7 +11,6 @@ name: Build and upload python package
 on:
   release:
     types: [published]
-  push:
 
 permissions:
   contents: read

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -42,8 +42,14 @@ jobs:
 
       - name: Build wheels for CPython
         run: |
+          # For cuda versions, rename the project with -cudaMAJORVER
           if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
-            sed -i "s/name = \"dedrift\"/name = \"dedrift-cuda${{ matrix.cuda_ver }}\"/g" pyproject.toml
+            if [[ "${{ matrix.cuda_ver }}" == 11.* ]]; then
+              sed -i "s/name = \"dedrift\"/name = \"dedrift-cuda11x\"/g" pyproject.toml
+            elif [[ "${{ matrix.cuda_ver }}" == 12.* ]]; then
+              sed -i "s/name = \"dedrift\"/name = \"dedrift-cuda12x\"/g" pyproject.toml
+            fi
+            # sed -i "s/name = \"dedrift\"/name = \"dedrift-cuda${{ matrix.cuda_ver }}\"/g" pyproject.toml
           fi
           python3 -m cibuildwheel --output-dir dist/
         env:
@@ -53,6 +59,8 @@ jobs:
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD_LINUX: |
             (yum install -y hdf5-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
+            # cibuildwheel uses --no-dep, but docs suggest build-system.requires should be installed...
+            # copying a version of fairseq approach https://github.com/facebookresearch/fairseq/blob/main/.github/workflows/release.yml#L128
             python3 -m pip install py-build-cmake~=0.2.0a7 cmake~=3.29.0 ninja~=1.11
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then
               yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo
@@ -60,7 +68,6 @@ jobs:
               yum install -y cuda-toolkit-${{ matrix.cuda_ver }}.x86_64
               export PATH=$PATH:/usr/local/cuda/bin
             fi
-            #sed -i "s/__version__ = '\([0-9.]*\)'/__version__ = '\1+cuda${{ matrix.cuda_ver }}'/g" /project/pyproject.toml
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.py-build-cmake_cache/editable/bliss/__init__.py
+++ b/.py-build-cmake_cache/editable/bliss/__init__.py
@@ -1,1 +1,0 @@
-/home/nathan/quadraturedev/customers/seti/bliss/bliss/python/bliss/__init__.py

--- a/bliss/python/CMakeLists.txt
+++ b/bliss/python/CMakeLists.txt
@@ -8,7 +8,13 @@ target_link_libraries(pybliss
     pyestimators
     pyfile_types
     pyflaggers
+    PRIVATE
+    fmt::fmt-header-only
 )
+
+if (WITH_CUDA)
+    target_link_libraries(pybliss PRIVATE CUDA::cudart_static)
+endif()
 
 # Check if PY_BUILD_CMAKE_MODULE_NAME is defined
 if(DEFINED PY_BUILD_CMAKE_MODULE_NAME)

--- a/bliss/python/bliss/__init__.py
+++ b/bliss/python/bliss/__init__.py
@@ -8,4 +8,4 @@ from . import pybland as bland
 
 from . import plot_utils
 
-__version__ = '0.1rc1'
+__version__ = '0.1rc2'

--- a/bliss/python/bliss/__init__.py
+++ b/bliss/python/bliss/__init__.py
@@ -8,4 +8,4 @@ from . import pybland as bland
 
 from . import plot_utils
 
-__version__ = f'0.0.1+cuda-{_cuda_version}'
+__version__ = '0.0.1'

--- a/bliss/python/bliss/__init__.py
+++ b/bliss/python/bliss/__init__.py
@@ -1,10 +1,11 @@
 """Breakthrough Listen Interesting Signal Search (BLISS): search
 radio astronomy data for SETI Technosignatures."""
 
-__version__ = '0.0.1'
 
 
 from .pybliss import *
 from . import pybland as bland
 
 from . import plot_utils
+
+__version__ = f'0.0.1+cuda-{_cuda_version}'

--- a/bliss/python/bliss/__init__.py
+++ b/bliss/python/bliss/__init__.py
@@ -8,4 +8,4 @@ from . import pybland as bland
 
 from . import plot_utils
 
-__version__ = '0.0.1'
+__version__ = '0.1rc1'

--- a/bliss/python/pybliss.cpp
+++ b/bliss/python/pybliss.cpp
@@ -12,10 +12,28 @@
 #include "estimators/pyestimators.hpp"
 #include "drift_search/pydrift_search.hpp"
 
+#if BLISS_CUDA
+#include <cuda_runtime.h>
+#endif
+
+#include <fmt/format.h>
+
 namespace nb = nanobind;
 using namespace nb::literals;
 
 NB_MODULE(pybliss, m) {
+
+    int cuda_runtime_version = 0;
+#if BLISS_CUDA
+    cudaRuntimeGetVersion(&cuda_runtime_version);
+#endif
+    std::string cuda_version_string = "none";
+    if (cuda_runtime_version != 0) {
+        int cuda_major = cuda_runtime_version/1000;
+        int cuda_minor = (cuda_runtime_version - 1000 * cuda_major)/10;
+        cuda_version_string = fmt::format("{}.{}", cuda_major, cuda_minor);
+    }
+    m.attr("_cuda_version") = cuda_version_string;
 
     bind_pycore(m);
 


### PR DESCRIPTION
This updates the wheel building process (happens on release) to use a matrix with 
* no cuda
* cuda 11.4 (version used on blpc servers)
* cuda 12.4 (new as of March 2024 https://developer.nvidia.com/cuda-toolkit-archive)

Each version creates its own project and uploads to pypi. So dedrift is cpu-only, dedrift-cuda11x has cuda 11, dedrift-cuda12x has cuda 12.4. The different projects are only relevant to pypi to keep cuda versions straight. This follows practice for cuda-runtime packages used by cupy and pytorch, etc