### PR TITLE
Cuda cc hitsearch

### DIFF
--- a/bliss/bliss_hits_to_dat.cpp
+++ b/bliss/bliss_hits_to_dat.cpp
@@ -43,8 +43,8 @@ int main(int argc, char *argv[]) {
     }
 
     for (const auto &f : hit_files) {
-        auto scan_with_hits = bliss::read_scan_hits_from_file(f);
-        for (auto &h : scan_with_hits.hits()) {
+        auto hits = bliss::read_hits_from_file(f);
+        for (auto &h : hits) {
             std::cout << h.repr() << std::endl;
         }
         // auto hits = bliss::read_hits_from_file(f);

--- a/bliss/core/scan.cpp
+++ b/bliss/core/scan.cpp
@@ -130,10 +130,10 @@ std::shared_ptr<coarse_channel> bliss::scan::read_coarse_channel(int coarse_chan
         auto global_start_fine_channel = _fine_channels_per_coarse * global_offset_in_file;
         data_offset[2] = global_start_fine_channel;
 
-        fmt::print("DEBUG: reading data from coarse channel {} which translates to offset {} + count {}\n",
-                   global_offset_in_file,
-                   data_offset,
-                   data_count);
+        // fmt::print("DEBUG: reading data from coarse channel {} which translates to offset {} + count {}\n",
+        //            global_offset_in_file,
+        //            data_offset,
+        //            data_count);
         auto data_reader = [h5_file_handle=this->_h5_file_handle, data_offset, data_count](){
             auto data = h5_file_handle->read_data(data_offset, data_count);
             return data;

--- a/bliss/drift_search/hit_search.cpp
+++ b/bliss/drift_search/hit_search.cpp
@@ -16,7 +16,7 @@ using namespace bliss;
 
 std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_options options) {
 
-    dedrifted_scan.set_device("cpu");
+    // dedrifted_scan.set_device("cpu");
     auto noise_estimate  = dedrifted_scan.noise_estimate();
     auto dedrifted_plane = dedrifted_scan.integrated_drift_plane();
 

--- a/bliss/drift_search/kernels/local_maxima_cuda.cu
+++ b/bliss/drift_search/kernels/local_maxima_cuda.cu
@@ -55,15 +55,15 @@ __global__ void local_maxima_kernel(float* doppler_spectrum_data,
                         auto neighbor_snr   = (neighbor_val - noise_floor) / neighbor_noise;
                         if (neighbor_snr > candidate_snr) {
                             neighborhood_max = false;
-                            break; // break sounds right, but may lead to warp divergeance. Benchmark!
+                            goto neighborhood_checked;
                         }
                     } else {
                         neighborhood_max = false;
-                        break;
+                        goto neighborhood_checked;
                     }
                 }
             }
-
+            neighborhood_checked:
             if (neighborhood_max) {
                 auto protohit_index = atomicAdd(number_protohits, 1);
                 protohits[protohit_index].index_max = {.drift_index=central_drift_index, .frequency_channel=central_frequency_channel};

--- a/bliss/file_types/h5_filterbank_file.cpp
+++ b/bliss/file_types/h5_filterbank_file.cpp
@@ -148,7 +148,11 @@ std::vector<int64_t> bliss::h5_filterbank_file::get_data_shape() {
         throw std::invalid_argument("Could not find a frequency dimension in dimension labels");
     }
     if (std::get<0>(time_steps) == read_data_attr<int64_t>("nchans") && std::get<0>(freq_bins) != read_data_attr<int64_t>("nchans")) {
-        fmt::print("WARN h5_filterbank_file: the DIMENSION_LABELS appear out of order, time dimension matches nchans\n");
+        static bool warning_issued = false;
+        if (!warning_issued) {
+            fmt::print("WARN h5_filterbank_file: the DIMENSION_LABELS appear out of order, time dimension matches nchans\n");
+            warning_issued = true;
+        }
         // There's some files that have the dim labels for time, channels swapped
         auto temp_time_steps = freq_bins;
         freq_bins            = time_steps;

--- a/bliss/file_types/hits_file.cpp
+++ b/bliss/file_types/hits_file.cpp
@@ -105,10 +105,8 @@ scan bliss::read_scan_hits_from_file(std::string_view file_path) {
 
         auto hit_reader        = message.getRoot<ScanDetections>();
         auto deserialized_scan = hit_reader.getScan();
-        fmt::print("Setting fields of scan\n");
         auto fch1 = deserialized_scan.getFch1();
         scan_with_hits.set_fch1(fch1);
-        fmt::print("made it here\n");
         scan_with_hits.set_foff(deserialized_scan.getFoff());
         scan_with_hits.set_tsamp(deserialized_scan.getTsamp());
         scan_with_hits.set_tstart(deserialized_scan.getTstart());
@@ -116,7 +114,6 @@ scan bliss::read_scan_hits_from_file(std::string_view file_path) {
         scan_with_hits.set_src_dej(deserialized_scan.getDec());
         scan_with_hits.set_src_raj(deserialized_scan.getRa());
         scan_with_hits.set_nchans(deserialized_scan.getNumChannels());
-        fmt::print("Done setting fields\n");
 
         std::list<hit> hits;
 
@@ -140,7 +137,6 @@ scan bliss::read_scan_hits_from_file(std::string_view file_path) {
         fmt::print("{}\n", e.what());
     }
 
-    fmt::print("returning scan\n");
 
     return scan_with_hits;
 }


### PR DESCRIPTION
Meant to address #48 and #49.

Right now, this seems correct and is fast. The current issue is it does not match 1:1 with the cpu variant, which is mostly because the CPU variant has logic that keeps connecting components as long as they are above snr_threshold/2 as a method that reduces false positives that just break away from the main cluster. This can be done, but needs slightly more careful attention and this commit/mr is meant as a marker of a working proof of concept

The main shift is a switch away from the iterative method based on union-find to an equivalence-based direct method. The three steps are
1) initialize labels
2) resolve roots
3) merge labels

This has a bit more rigorous graph theory elements to it and can trace back to good literature but is unique to our data / needs