### PR TITLE
create mask when not present in hdf5

### DIFF
--- a/bliss/file_types/h5_filterbank_file.cpp
+++ b/bliss/file_types/h5_filterbank_file.cpp
@@ -145,9 +145,21 @@ bliss::h5_filterbank_file::h5_filterbank_file(std::string_view file_path) {
     }
 
     // TODO: what is the support matrix we can handle?
-    if (read_file_attr<std::string>("VERSION") != "1.0") {
-        throw std::invalid_argument("H5 file VERSION is not 1.0");
+    // We know most telescopes and archive data are 1.0 and GBT currently emits 2.0
+    constexpr std::array<const char*, 2> supported_filterbank_versions = {"1.0", "2.0"};
+
+    auto filterbank_version = read_file_attr<std::string>("VERSION");
+    if (!std::any_of(supported_filterbank_versions.begin(),
+                     supported_filterbank_versions.end(),
+                     [filterbank_version](const char* supported_version) { return supported_version == filterbank_version; })) {
+
+        auto warning = fmt::format("WARN: h5_filterbank_file: H5 FILTERBANK file VERSION field ({}) is not in known supported "
+                    "versions list {}. Trying to read it anyway!\n",
+                    filterbank_version,
+                    supported_filterbank_versions);
+        fmt::print(warning);
     }
+
 }
 
 

--- a/bliss/file_types/h5_filterbank_file.cpp
+++ b/bliss/file_types/h5_filterbank_file.cpp
@@ -131,9 +131,13 @@ bliss::h5_filterbank_file::h5_filterbank_file(std::string_view file_path) {
     }
 
     try {
-        _h5_mask_handle = _h5_file_handle.openDataSet("mask");
+        if (_h5_file_handle.nameExists("mask")) {
+                _h5_mask_handle = _h5_file_handle.openDataSet("mask");
+        } else {
+            fmt::print("INFO: h5_filterbank_file: mask is not in this file. This is recoverable.\n");
+        }
     } catch (H5::FileIException h5_mask_exception) {
-        fmt::print("INFO: h5_filterbank_file: got an exception while reading mask. This is recoverable.\n");
+        fmt::print("WARN: h5_filterbank_file: got an exception while reading mask. This is recoverable.\n");
     }
 
     if (read_file_attr<std::string>("CLASS") != "FILTERBANK") {

--- a/bliss/file_types/include/file_types/h5_filterbank_file.hpp
+++ b/bliss/file_types/include/file_types/h5_filterbank_file.hpp
@@ -71,7 +71,7 @@ class h5_filterbank_file {
   private:
     H5::H5File  _h5_file_handle;
     H5::DataSet _h5_data_handle;
-    H5::DataSet _h5_mask_handle;
+    std::optional<H5::DataSet> _h5_mask_handle;
 };
 
 template <typename T>


### PR DESCRIPTION
Closes #65. Some files (many of the recent files) do not have a `mask` dataset in the hdf5 file. It's always uint8 and zero, so this sets the hdf5 mask handle as optional and just creates a zero-valued mask of appropriate size when it's not present.