### PR TITLE
improve error messages when doing hit_search without a noise estimate

### DIFF
--- a/bliss/core/coarse_channel.cpp
+++ b/bliss/core/coarse_channel.cpp
@@ -140,7 +140,12 @@ void bliss::coarse_channel::set_mask(bland::ndarray_deferred deferred_mask) {
 }
 
 noise_stats bliss::coarse_channel::noise_estimate() const {
-    return _noise_stats.value();
+    if (_noise_stats.has_value()) {
+        return _noise_stats.value();
+    } else {
+        fmt::print("coarse_channel::noise_estimate: requested noise estimate which does not exist yet.");
+        throw std::runtime_error("coarse_channel::noise_estimate: requested noise estimate which does not exist");
+    }
 }
 
 void bliss::coarse_channel::set_noise_estimate(noise_stats estimate) {

--- a/bliss/drift_search/hit_search.cpp
+++ b/bliss/drift_search/hit_search.cpp
@@ -16,7 +16,6 @@ using namespace bliss;
 
 std::list<hit> bliss::hit_search(coarse_channel dedrifted_scan, hit_search_options options) {
 
-    // dedrifted_scan.set_device("cpu");
     auto noise_estimate  = dedrifted_scan.noise_estimate();
     auto dedrifted_plane = dedrifted_scan.integrated_drift_plane();
 


### PR DESCRIPTION
noise estimates in a coarse_channel are stored as std::optional to keep the execution deferred. Rather than just forcing out a value, check to see if there is a value and print a message + throw exception that makes it more clear why the failure occurred rather than just a "bad optional access" exception