### PR TITLE
make bland cuda_runtime include/link public since it is in public header

### DIFF
--- a/bland/bland/CMakeLists.txt
+++ b/bland/bland/CMakeLists.txt
@@ -34,8 +34,9 @@ if (WITH_CUDA)
     )
 
     target_link_libraries(bland
-        PRIVATE
+        PUBLIC
         CUDA::cudart_static
+        PRIVATE
         CUDA::cufft
     )
 

--- a/bliss/CMakeLists.txt
+++ b/bliss/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(bliss_generate_channelizer_response
 add_executable(bliss_find_hits bliss_find_hits.cpp)
 target_link_libraries(bliss_find_hits
     bliss_core
+    bliss_preprocess
     drift_search
     estimators
     bliss_serialization

--- a/bliss/core/cadence.cpp
+++ b/bliss/core/cadence.cpp
@@ -105,6 +105,7 @@ void bliss::observation_target::set_device(bland::ndarray::dev& device, bool ver
             throw std::runtime_error("set_device received invalid cuda device");
         }
     }
+    _device = device;
 
     for (auto &target_scan : _scans) {
         target_scan.set_device(device, false);
@@ -197,6 +198,8 @@ void bliss::cadence::set_device(bland::ndarray::dev& device, bool verbose) {
             throw std::runtime_error("set_device received invalid cuda device");
         }
     }
+
+    _device = device;
 
     for (auto &target : _observations) {
         target.set_device(device, false);

--- a/bliss/drift_search/kernels/connected_components_cuda.cu
+++ b/bliss/drift_search/kernels/connected_components_cuda.cu
@@ -353,7 +353,6 @@ bliss::find_components_above_threshold_cuda(bland::ndarray                   dop
     // We can only possibly have one max for every neighborhood, so that's a reasonably efficient max neighborhood
     int number_protohits = numel / (neighbor_l1_dist*neighbor_l1_dist);
     auto dev_protohits = safe_device_vector<device_protohit>(number_protohits);
-    fmt::print("Are we making it here? where does our exception go");
 
     // All malloc's in one place to make it easier to track down free's later on
     int* m_num_maxima;

--- a/bliss/preprocess/passband_static_equalize.cpp
+++ b/bliss/preprocess/passband_static_equalize.cpp
@@ -96,12 +96,12 @@ bland::ndarray bliss::gen_coarse_channel_response(int fine_per_coarse, int num_c
 
     H.reshape({number_coarse_channels_contributing, fine_per_coarse});
 
-    bland::write_to_file(H, "H_sliced_reshaped_magsquare.cuda_f32");
+    // bland::write_to_file(H, "H_sliced_reshaped_magsquare.cuda_f32");
 
     H = bland::sum(H, {0}); // sum all of the energy from adjacent channels that folds back in
     H = H/bland::max(H); // normalize
 
-    bland::write_to_file(H, "H_normalized.cuda_f32");
+    // bland::write_to_file(H, "H_normalized.cuda_f32");
 
     return H;
 }
@@ -146,6 +146,7 @@ observation_target bliss::equalize_passband_filter(observation_target ot, bland:
 
 observation_target bliss::equalize_passband_filter(observation_target ot, std::string_view h_resp_filepath, bland::ndarray::datatype dtype) {
     auto h = bland::read_from_file(h_resp_filepath, dtype);
+    h = h.to(ot.device());
     return equalize_passband_filter(ot, h);
 }
 


### PR DESCRIPTION
Fixes a minor issue or two with building at ata on comp-node3

legit issues with dependency graph that more flexible compilers didn't care about