### PR TITLE
Various fixes (memory leak fix)

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -58,8 +58,8 @@ jobs:
           #CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           # CIBW_BEFORE_BUILD: python -m pip install py-build-cmake~=0.2.0a7 cmake~=3.29.0 ninja
           CIBW_BEFORE_ALL: python -m pip install py-build-cmake~=0.2.0a7 cmake~=3.29.0 ninja
-          CIBW_BEFORE_BUILD_LINUX: |
-            (yum install -y hdf5-devel fftw-devel || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
+          CIBW_BEFORE_ALL_LINUX: |
+            (yum install -y fftw-devel && curl -s -L https://hdf-wordpress-1.s3.amazonaws.com/wp-content/uploads/manual/HDF5/HDF5_1_14_3/src/CMake-hdf5-1.14.3.tar.gz  | tar xz -C /tmp && cmake -DCMAKE_INSTALL_PREFIX=/usr/local -S /tmp/CMake-hdf5-1.14.3/hdf5-1.14.3 -B hdf5-build -C /tmp/CMake-hdf5-1.14.3/hdf5-1.14.3/config/cmake/cacheinit.cmake -DHDF5_BUILD_JAVA=OFF -DHDF5_BUILD_FORTRAN=OFF -DHDF5_ALLOW_EXTERNAL_SUPPORT=git && cmake --build hdf5-build -j $(nproc) --config Release && cmake --install hdf5-build || apt-get install -y libhdf5-dev || apk add --update --no-cache hdf5-dev || true) && true
             # cibuildwheel uses --no-dep, but docs suggest build-system.requires should be installed...
             # copying a version of fairseq approach https://github.com/facebookresearch/fairseq/blob/main/.github/workflows/release.yml#L128
             if [[ "${{ matrix.cuda_ver }}" != "none" ]]; then

--- a/bland/bland/config.cpp
+++ b/bland/bland/config.cpp
@@ -26,14 +26,19 @@ std::pair<std::map<int, config::cuda_device_attributes>, std::vector<int>> check
     std::map<int, config::cuda_device_attributes> useable_devices;
     std::vector<int> nonuseable_devices;
 
+    cudaDeviceProp deviceProp;
     for (int device_index = 0; device_index < device_count; ++device_index) {
-        cudaDeviceProp deviceProp;
         cudaGetDeviceProperties(&deviceProp, device_index);
 
         int runtime_arch = deviceProp.major * 10 + deviceProp.minor;
 
         if (std::find(compiled_archs.begin(), compiled_archs.end(), runtime_arch) != compiled_archs.end()) {
-            useable_devices[device_index] = deviceProp;
+            auto uuid_bytes = deviceProp.uuid.bytes;
+            useable_devices[device_index] = {.name=deviceProp.name, .uuid={}};
+            for (int ii=0; ii < sizeof(deviceProp.uuid); ++ii) {
+                useable_devices[device_index].uuid += fmt::format("{:02x}", uuid_bytes[ii]);
+            }
+            fmt::print("Found a usable device\n");
         } else {
             fmt::print("WARN: Device {} has compute architecture {}.{} which is incompatible with this build.\n", device_index, deviceProp.major, deviceProp.minor);
             nonuseable_devices.emplace_back(device_index);
@@ -46,34 +51,29 @@ std::pair<std::map<int, config::cuda_device_attributes>, std::vector<int>> check
 #endif
 }
 
-    config::config()  {
-        auto devices = check_cuda_architectures();
-        _valid_cuda_devices = devices.first;
-        _invalid_cuda_devices = devices.second;
-    }
+config::config()  {
+    auto devices = check_cuda_architectures();
+    _valid_cuda_devices = devices.first;
+    _invalid_cuda_devices = devices.second;
+}
 
 
-    std::map<int, config::cuda_device_attributes> config::get_valid_cuda_devices() {
-        return _valid_cuda_devices;
-    }
+std::map<int, config::cuda_device_attributes> config::get_valid_cuda_devices() {
+    return _valid_cuda_devices;
+}
 
-    bool config::check_is_valid_cuda_device(int device_index, bool verbose) {
-        bool valid_device = std::any_of(_valid_cuda_devices.begin(), _valid_cuda_devices.end(), [device_index](std::pair<int, cuda_device_attributes> valid_dev) {return valid_dev.first == device_index;});
-        if (verbose) {
-            if (valid_device) {
-                auto uuid_bytes = _valid_cuda_devices[device_index].uuid.bytes;
-                std::string uuid_pp;
-                for (int ii=0; ii < sizeof(_valid_cuda_devices[device_index].uuid); ++ii) {
-                    uuid_pp += fmt::format("{:02x}", uuid_bytes[ii]);
-                }
-                fmt::print("INFO: using cuda:{} :: {} (UUID: {})\n", device_index, _valid_cuda_devices[device_index].name, uuid_pp);
 
-            } else {
-                fmt::print("The selected device id either does not exist or has a compute capability that is not compatible with this build\n");
-            }
+bool config::check_is_valid_cuda_device(int device_index, bool verbose) {
+    bool valid_device = std::any_of(_valid_cuda_devices.begin(), _valid_cuda_devices.end(), [device_index](std::pair<int, cuda_device_attributes> valid_dev) {return valid_dev.first == device_index;});
+    if (verbose) {
+        if (valid_device) {
+            fmt::print("INFO: using cuda:{} :: {} (UUID: {})\n", device_index, _valid_cuda_devices[device_index].name, _valid_cuda_devices[device_index].uuid);
+        } else {
+            fmt::print("The selected device id either does not exist or has a compute capability that is not compatible with this build\n");
         }
-        return valid_device;
     }
+    return valid_device;
+}
 
 }
 

--- a/bland/bland/include/bland/config.hpp
+++ b/bland/bland/include/bland/config.hpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <map>
+#include <string>
 #include <vector>
 
 namespace bland {
@@ -16,15 +17,15 @@ namespace bland {
 class config {
 public:
 
-#if BLAND_CUDA_CODE
-    using cuda_device_attributes = cudaDeviceProp;
-#else
+// #if BLAND_CUDA_CODE
+//     using cuda_device_attributes = cudaDeviceProp;
+// #else
     // Here to make the conditional compilation of used fields restricted to one place
     struct cuda_device_attributes {
-        char name[256];                  /**< ASCII string identifying device */
-        struct {char bytes[16];} uuid;    /**< 16-byte unique identifier */
+        std::string name;                  /**< ASCII string identifying device */
+        std::string uuid;                   /**< 16-byte unique identifier */
     };
-#endif
+// #endif
 
     static config& get_instance() {
         static config instance;

--- a/bland/bland/ndarray_deferred.cpp
+++ b/bland/bland/ndarray_deferred.cpp
@@ -22,7 +22,9 @@ bland::ndarray_deferred::ndarray_deferred(ndarray pod)
 ndarray_deferred bland::ndarray_deferred::to(bland::ndarray::dev device) {
     _device = device;
     if (std::holds_alternative<ndarray>(*_deferred_data)) {
-        *_deferred_data = std::get<ndarray>(*_deferred_data).to(_device.value());
+        auto unmemoized_array = std::get<ndarray>(*_deferred_data);
+        auto on_device = unmemoized_array.to(_device.value());
+        _deferred_data = std::make_shared<std::variant<bland::ndarray, std::function<bland::ndarray ()>>>(on_device);
     }
     return *this;
 }

--- a/bliss/CMakeLists.txt
+++ b/bliss/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(
          bliss_serialization
          flaggers
          fmt::fmt-header-only
-	 stdc++fs
+         stdc++fs
 )
 
 install(TARGETS bliss_find_hits RUNTIME COMPONENT bliss_executables DESTINATION bin)

--- a/bliss/bliss_find_hits.cpp
+++ b/bliss/bliss_find_hits.cpp
@@ -65,8 +65,9 @@ int main(int argc, char *argv[]) {
             // Drift intgration / dedoppler
             (clipp::option("--desmear") .set(dedrift_options.desmear, true) |
              clipp::option("--nodesmear").set(dedrift_options.desmear, false)) % "Desmear the drift plane to compensate for drift rate crossing channels",
-            (clipp::option("-m", "--min-rate") & clipp::value("min-rate").set(dedrift_options.low_rate)) % "Minimum drift rate (-5 Hz/sec)",
-            (clipp::option("-M", "--max-rate") & clipp::value("max-rate").set(dedrift_options.high_rate)) % "Maximum drift rate (+5 Hz/sec)",
+            (clipp::option("-m", "--min-rate") & clipp::value("min-rate").set(dedrift_options.low_rate)) % "Minimum drift rate (fourier bins)",
+            (clipp::option("-rs", "--rate-step") & clipp::value("rate-step").set(dedrift_options.rate_step_size)) % "Fourier bins to step per search",
+            (clipp::option("-M", "--max-rate") & clipp::value("max-rate").set(dedrift_options.high_rate)) % "Maximum drift rate (fourier bins)",
 
             // Hit search
             (clipp::option("--local-maxima") .set(hit_search_options.method, bliss::hit_search_methods::LOCAL_MAXIMA) |

--- a/bliss/core/scan.cpp
+++ b/bliss/core/scan.cpp
@@ -355,7 +355,7 @@ void bliss::scan::push_device() {
 
 bliss::scan bliss::scan::slice_scan_channels(int start_channel, int count) {
     if (count == -1) {
-        fmt::print("Got count of -1, replacing with {} - {} = {}\n", get_number_coarse_channels(), start_channel, get_number_coarse_channels() - start_channel);
+        fmt::print("INFO: Got count of -1 channels, automatically extending to last coarse channel ({})\n", get_number_coarse_channels(), get_number_coarse_channels() - start_channel);
         count = get_number_coarse_channels() - start_channel;
     }
 

--- a/bliss/file_types/h5_filterbank_file.cpp
+++ b/bliss/file_types/h5_filterbank_file.cpp
@@ -332,47 +332,45 @@ bland::ndarray bliss::h5_filterbank_file::read_data(std::vector<int64_t> offset,
 }
 
 bland::ndarray bliss::h5_filterbank_file::read_mask(std::vector<int64_t> offset, std::vector<int64_t> count) {
-    if (_h5_mask_handle.has_value()) {
-        auto h5_mask = _h5_mask_handle.value();
-        auto dataspace   = h5_mask.getSpace();
-        auto number_dims = dataspace.getSimpleExtentNdims();
+    // if (_h5_mask_handle.has_value()) {
+    //     auto h5_mask = _h5_mask_handle.value();
+    //     auto dataspace   = h5_mask.getSpace();
+    //     auto number_dims = dataspace.getSimpleExtentNdims();
 
-        bland::ndarray mask_grid;
+    //     auto shape = get_data_shape();
 
-        auto shape = get_data_shape();
+    //     if (offset.empty()) {
+    //         offset = std::vector<int64_t>(shape.size(), 0);
+    //     }
+    //     if (count.empty()) {
+    //         count = shape;
+    //         count[0] -= offset[0];
+    //         count[1] -= offset[1];
+    //         count[2] -= offset[2];
+    //     }
+    //     auto mask_grid = bland::ndarray(count, bland::ndarray::datatype::uint8, bland::ndarray::dev::cpu);
+    //     // TODO: validate both offset and count are size 3
 
-        if (offset.empty()) {
-            offset = std::vector<int64_t>(shape.size(), 0);
-        }
-        if (count.empty()) {
-            count = shape;
-            count[0] -= offset[0];
-            count[1] -= offset[1];
-            count[2] -= offset[2];
-        }
-        mask_grid = bland::ndarray(count, bland::ndarray::datatype::uint8, bland::ndarray::dev::cpu);
-        // TODO: validate both offset and count are size 3
+    //     std::vector<hsize_t> offset_hsize(offset.begin(), offset.end());
+    //     std::vector<hsize_t> count_hsize(count.begin(), count.end());
 
-        std::vector<hsize_t> offset_hsize(offset.begin(), offset.end());
-        std::vector<hsize_t> count_hsize(count.begin(), count.end());
+    //     dataspace.selectHyperslab(H5S_SELECT_SET, count_hsize.data(), offset_hsize.data());
 
-        dataspace.selectHyperslab(H5S_SELECT_SET, count_hsize.data(), offset_hsize.data());
+    //     // Define the memory dataspace to receive the read data
+    //     std::vector<hsize_t> grid_shape(count.begin(), count.end());
+    //     H5::DataSpace        memspace(grid_shape.size(), grid_shape.data());
 
-        // Define the memory dataspace to receive the read data
-        std::vector<hsize_t> grid_shape(count.begin(), count.end());
-        H5::DataSpace        memspace(grid_shape.size(), grid_shape.data());
+    //     // The row-major reading and axes we set up means frequency (most dense) is in last dim
+    //     h5_mask.read(mask_grid.data_ptr<uint8_t>(), H5::PredType::NATIVE_UINT8, memspace, dataspace);
 
-        // The row-major reading and axes we set up means frequency (most dense) is in last dim
-        h5_mask.read(mask_grid.data_ptr<float>(), H5::PredType::NATIVE_UINT8, memspace, dataspace);
-
-        mask_grid = mask_grid.squeeze(1); // squeeze out the feed_id
-        return mask_grid;
-    } else {
+    //     mask_grid = mask_grid.squeeze(1); // squeeze out the feed_id
+    //     return mask_grid;
+    // } else {
         // The file has no "mask" dataset, it's typically zeros anyway so just allocate the appropriate number of uint8 zeros
-        auto mask_grid = bland::zeros(count, bland::ndarray::datatype::uint8, bland::ndarray::dev::cpu);
+        auto mask_grid = bland::zeros(count, bland::ndarray::datatype::uint8, bland::ndarray::dev::cuda);
         mask_grid = mask_grid.squeeze(1); // squeeze out the feed_id
         return mask_grid;
-    }
+    // }
 }
 
 std::string bliss::h5_filterbank_file::repr() {

--- a/bliss/file_types/h5_filterbank_file.cpp
+++ b/bliss/file_types/h5_filterbank_file.cpp
@@ -10,6 +10,8 @@
 
 using namespace bliss;
 
+constexpr bool pedantic = false;
+
 // Default implementation for reading data_attr
 template <typename T>
 T bliss::h5_filterbank_file::read_data_attr(const std::string &key) {
@@ -20,34 +22,58 @@ T bliss::h5_filterbank_file::read_data_attr(const std::string &key) {
 
         // Check the data type and perform the appropriate casting
         if (dtype == H5::PredType::NATIVE_INT16) {
+            if constexpr (pedantic && !std::is_same_v<int16_t, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_INT16 in file\n", key, typeid(T).name());
+            }
             int16_t val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
         } else if (dtype == H5::PredType::NATIVE_UINT16) {
+            if constexpr (pedantic && !std::is_same_v<uint16_t, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_UINT16 in file\n", key, typeid(T).name());
+            }
             uint16_t val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
         } else if (dtype == H5::PredType::NATIVE_INT32) {
+            if constexpr (pedantic && !std::is_same_v<int32_t, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_INT32 in file\n", key, typeid(T).name());
+            }
             int32_t val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
         } else if (dtype == H5::PredType::NATIVE_UINT32) {
+            if constexpr (pedantic && !std::is_same_v<uint32_t, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_UINT32 in file\n", key, typeid(T).name());
+            }
             uint32_t val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
         }  else if (dtype == H5::PredType::NATIVE_INT64) {
+            if constexpr (pedantic && !std::is_same_v<int64_t, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_INT64 in file\n", key, typeid(T).name());
+            }
             int64_t val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
         }  else if (dtype == H5::PredType::NATIVE_UINT64) {
+            if constexpr (pedantic && !std::is_same_v<uint64_t, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_UINT64 in file\n", key, typeid(T).name());
+            }
             uint64_t val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
         }  else if (dtype == H5::PredType::NATIVE_FLOAT) {
+            if constexpr (pedantic && !std::is_same_v<float, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_FLOAT in file\n", key, typeid(T).name());
+            }
             float val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
         }  else if (dtype == H5::PredType::NATIVE_DOUBLE) {
+            if constexpr (pedantic && !std::is_same_v<double, T>) {
+                fmt::print("WARN: attr {} requested as {} but is NATIVE_DOUBLE in file\n", key, typeid(T).name());
+            }
             double val;
             attr.read(dtype, &val);
             return static_cast<T>(val);
@@ -108,9 +134,8 @@ std::string bliss::h5_filterbank_file::read_data_attr<std::string>(const std::st
 
             return result;
         } else {
-            std::string val;
-            attr.read(dtype, &val);
-            return val;
+            auto err_msg = fmt::format("{} expected as string but is not a string type");
+            throw std::invalid_argument(err_msg);
         }
     } else {
         auto err_msg = fmt::format("H5 data does not have an attribute key {}", key);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = []
 minimum_version = "3.18"
 build_type = "RelWithDebInfo"
 source_path = "." # Containing CMakeLists.txt
-build_path = "build"
+build_path = "build-wheel"
 options = { "WITH_PY_STUBS:BOOL" = "On" }
 args = ["-Wdev"]
 find_python = true


### PR DESCRIPTION
Most importantly, I found the memory leak Carmen was reporting that occurred in `ndarray_deferred`  device movement. There was an ownership / transfer bug that is now fixed by making a new shared_ptr rather than assigning a copy that gets lost.

This also changes the cuda attributes tracking to always use our custom (smaller) object which was **probably** a red herring but a result of vtune memory profiling.

Expose a drift range stride to `bliss_find_hits` by request.

Always create our own mask of all zeros and never read the mask from disk. This probably doesn't matter a ton on many cases, but should help with the networked read / chunking business that was reported.

Packaging wheels (for pypi) is a little bit better and understood better. We now build a new version of hdf5 for our pypi package that handles plugins better. It's now possible to use the executables in the wheel. It's useful to know that auditwheel does rpath fixing and shoves any linked shared libs to the wheel. This isn't necessarily great, but no standard solution around this seems to exist. I don't know the best way to handle finding bitshuffle (or packaging it inside the wheel for discovery) so it's not 100% ready to go, but way closer