### PR TITLE
Improved flaggers (adds sigmaclip and fixes a spectral kurtosis default setting)

### DIFF
--- a/bland/bland/include/bland/ops/ops_statistical.hpp
+++ b/bland/bland/include/bland/ops/ops_statistical.hpp
@@ -39,6 +39,12 @@ ndarray var(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 ndarray masked_var(const ndarray &a, const ndarray &mask, std::vector<int64_t> axes={});
 ndarray masked_var(const ndarray &a, const ndarray &mask, ndarray &out, std::vector<int64_t> axes={});
 
+std::pair<ndarray, ndarray> mean_stddev(const ndarray &a, std::vector<int64_t> axes={});
+std::pair<ndarray, ndarray> mean_stddev(const ndarray &a, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> axes={});
+
+std::pair<ndarray, ndarray> masked_mean_stddev(const ndarray &a, const ndarray &mask, std::vector<int64_t> axes={});
+std::pair<ndarray, ndarray> masked_mean_stddev(const ndarray &a, const ndarray &mask, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> axes={});
+
 ndarray standardized_moment(const ndarray &a, int degree, std::vector<int64_t> axes={});
 ndarray standardized_moment(const ndarray &a, int degree, ndarray &out, std::vector<int64_t> axes={});
 

--- a/bland/bland/ops/cpu/statistical_cpu.cpp
+++ b/bland/bland/ops/cpu/statistical_cpu.cpp
@@ -55,7 +55,7 @@ struct mean_impl {
         constexpr bool is_floating_point = std::is_floating_point<out_datatype>::value;
         using accumulator_type = std::conditional_t<is_floating_point, double, out_datatype>;
 
-        out_datatype scale = 1.0 / static_cast<out_datatype>(reduced_elements - 1);
+        accumulator_type scale = 1.0 / static_cast<accumulator_type>(reduced_elements - 1);
         auto numel = out.numel();
         for (int i = 0; i < numel; ++i) {
             // Make a copy of the current input index, we'll fix the non-summed dims
@@ -280,7 +280,7 @@ struct stddev_impl {
         using accumulator_type = std::conditional_t<is_floating_point, double, out_datatype>;
 
         // TODO (flexibility): add correction option (noff in torch)
-        out_datatype scale = 1.0 / static_cast<out_datatype>(reduced_elements);
+        accumulator_type scale = 1.0 / static_cast<accumulator_type>(reduced_elements);
 
         auto numel = out.numel();
         for (int i = 0; i < numel; ++i) {
@@ -299,7 +299,7 @@ struct stddev_impl {
                 }
                 auto x = a_data[input_linear_index];
                 accum_x += x * scale;
-                accum_x2 += x*x * scale;
+                accum_x2 += static_cast<accumulator_type>(x) * x * scale;
                 // Increment the multi-dimensional index
                 for (int i = reduced_axes.size() - 1; i >= 0; --i) {
                     auto d = reduced_axes[i];
@@ -406,7 +406,7 @@ struct masked_stddev_impl {
         using accumulator_type = std::conditional_t<is_floating_point, double, out_datatype>;
 
         // TODO (flexibility): add correction option (noff in torch)
-        out_datatype scale = 1.0 / static_cast<out_datatype>(reduced_elements);
+        accumulator_type scale = 1.0 / static_cast<accumulator_type>(reduced_elements);
 
         auto numel = out.numel();
         for (int i = 0; i < numel; ++i) {
@@ -428,7 +428,7 @@ struct masked_stddev_impl {
                 if (mask_data[input_linear_index] == 0) {
                     auto x = a_data[input_linear_index];
                     accum_x += x;
-                    accum_x2 += x*x;
+                    accum_x2 += static_cast<accumulator_type>(x) * x;
                     elements_in_dev += 1;
                 }
                 // Increment the multi-dimensional index
@@ -532,7 +532,7 @@ bland::cpu::mean_stddev(const ndarray &a, ndarray &out_mean, ndarray &out_stddev
     using accumulator_type           = std::conditional_t<is_floating_point, double, out_datatype>;
 
     // TODO (flexibility): add correction option (noff in torch)
-    out_datatype scale = 1.0 / static_cast<out_datatype>(reduced_elements);
+    accumulator_type scale = 1.0 / static_cast<accumulator_type>(reduced_elements);
 
     auto numel = out_mean.numel();
     for (int i = 0; i < numel; ++i) {
@@ -551,7 +551,7 @@ bland::cpu::mean_stddev(const ndarray &a, ndarray &out_mean, ndarray &out_stddev
             }
             auto x = a_data[input_linear_index];
             accum_x += x * scale;
-            accum_x2 += x * x * scale;
+            accum_x2 += static_cast<accumulator_type>(x) * x * scale;
             // Increment the multi-dimensional index
             for (int i = reduced_axes.size() - 1; i >= 0; --i) {
                 auto d = reduced_axes[i];
@@ -662,7 +662,7 @@ std::pair<ndarray, ndarray> bland::cpu::masked_mean_stddev(const ndarray &a, con
         using accumulator_type = std::conditional_t<is_floating_point, double, out_datatype>;
 
         // TODO (flexibility): add correction option (noff in torch)
-        out_datatype scale = 1.0 / static_cast<out_datatype>(reduced_elements);
+        accumulator_type scale = 1.0 / static_cast<accumulator_type>(reduced_elements);
 
         auto numel = out_mean.numel();
         for (int i = 0; i < numel; ++i) {
@@ -684,7 +684,7 @@ std::pair<ndarray, ndarray> bland::cpu::masked_mean_stddev(const ndarray &a, con
                 if (mask_data[input_linear_index] == 0) {
                     auto x = a_data[input_linear_index];
                     accum_x += x;
-                    accum_x2 += x*x;
+                    accum_x2 += static_cast<accumulator_type>(x) * x;
                     elements_in_dev += 1;
                 }
                 // Increment the multi-dimensional index
@@ -795,7 +795,7 @@ struct standardized_moment_impl {
         std::vector<int64_t> input_index(a_shape.size(), 0);
 
         // TODO (flexibility): add correction option (noff in torch)
-        out_datatype scale = 1.0 / static_cast<out_datatype>(reduced_elements - 1);
+        double scale = 1.0 / static_cast<double>(reduced_elements - 1);
 
         auto numel = out.numel();
         for (int i = 0; i < numel; ++i) {

--- a/bland/bland/ops/cpu/statistical_cpu.hpp
+++ b/bland/bland/ops/cpu/statistical_cpu.hpp
@@ -26,6 +26,10 @@ ndarray stddev(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 
 ndarray masked_stddev(const ndarray &a, const ndarray &mask, ndarray &out, std::vector<int64_t> axes={});
 
+std::pair<ndarray, ndarray> mean_stddev(const ndarray &a, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> axes={});
+
+std::pair<ndarray, ndarray> masked_mean_stddev(const ndarray &a, const ndarray &mask, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> axes={});
+
 ndarray var(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 
 ndarray masked_var(const ndarray &a, const ndarray &mask, ndarray &out, std::vector<int64_t> axes={});

--- a/bland/bland/ops/cuda/statistical.cuh
+++ b/bland/bland/ops/cuda/statistical.cuh
@@ -28,11 +28,15 @@ ndarray stddev(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 
 ndarray masked_stddev(const ndarray &a, const ndarray &mask, ndarray &out, std::vector<int64_t> axes={});
 
+std::pair<ndarray, ndarray> mean_stddev(const ndarray &a, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> axes={});
+
+std::pair<ndarray, ndarray> masked_mean_stddev(const ndarray &a, const ndarray &mask, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> axes={});
+
 ndarray var(const ndarray &a, ndarray &out, std::vector<int64_t> axes={});
 
 ndarray masked_var(const ndarray &a, const ndarray &mask, ndarray &out, std::vector<int64_t> axes={});
 
-ndarray standardized_moment(const ndarray &a, int degree, ndarray &out, std::vector<int64_t> axes={});
+// ndarray standardized_moment(const ndarray &a, int degree, ndarray &out, std::vector<int64_t> axes={});
 
 
 // TODO

--- a/bland/bland/ops/cuda/statistical_cuda.cu
+++ b/bland/bland/ops/cuda/statistical_cuda.cu
@@ -316,6 +316,210 @@ __global__ void reduction_impl(out_datatype* out_data, int64_t* out_shape, int64
     }
 }
 
+
+// Non-masked reductions, hard coded to float for now
+// template <typename out_datatype, typename in_datatype, reductiontype Op>
+__global__ void mean_stddev_impl(float* mean_out_data, int64_t* mean_out_shape, int64_t* mean_out_strides, int64_t mean_out_ndim, int64_t mean_out_numel,
+                        float* stddev_out_data, int64_t* stddev_out_shape, int64_t* stddev_out_strides, int64_t stddev_out_ndim, int64_t stddev_out_numel,
+                        float* a_data, int64_t* a_shape, int64_t* a_strides, int64_t a_ndim,
+                        int64_t* reduced_axes, int64_t nreduced_dim, int64_t reduction_factor) {
+    // A good primer on reduction kernels: https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
+
+    using out_datatype = float;
+    using in_datatype = float;
+    using accumulator_type = float;
+    auto tid = threadIdx.x;
+    auto outer_workid = blockIdx.x;
+    auto outer_gridsize = gridDim.x;
+
+    // Assume we've been given shared memory with enough space for each thread
+    // to hold an accumulator of the in_datatype size (and one for x^2 if stddev or var)
+    // Break that shared memory up in to appropriate chunks easily indexed by smem
+    extern __shared__ char shared_memory[];
+    accumulator_type* sdata = reinterpret_cast<accumulator_type*>(shared_memory);
+    accumulator_type sdata_c = 0;
+    accumulator_type* s2data = sdata + blockDim.x;
+    accumulator_type s2data_c = 0;
+
+    int64_t mean_out_index[MAX_NDIM] = {0};
+    int64_t stddev_out_index[MAX_NDIM] = {0};
+    int64_t in_index[MAX_NDIM] = {0};
+    int64_t reduced_nd_index[MAX_NDIM] = {0};
+
+    // Initialize ndindex per threadblock
+    auto flattened_work_item = outer_workid;
+    for (int dim = mean_out_ndim - 1; dim >= 0; --dim) {
+        mean_out_index[dim] = flattened_work_item % mean_out_shape[dim];
+        flattened_work_item /= mean_out_shape[dim];
+    }
+    flattened_work_item = outer_workid;
+    for (int dim = a_ndim - 1; dim >= 0; --dim) {
+        bool reduce_this_dim = false;
+        for (int ra=0; ra < nreduced_dim; ++ra) {
+            if (dim == reduced_axes[ra]) {
+                reduce_this_dim = true;
+                break;
+            }
+        }
+        if (!reduce_this_dim) {
+            in_index[dim] = flattened_work_item % a_shape[dim];
+            flattened_work_item /= a_shape[dim];
+        }
+    }
+
+    auto numel = mean_out_numel;
+    for (int64_t i = outer_workid; i < numel; i+=outer_gridsize) {
+        // Reset accumulators
+        sdata[tid] = 0;
+        s2data[tid] = 0;
+        // Deep copy the input index which is advancing over non-reduced inputs
+        // to reduced_nd_index which will be used in inner loop to advance through
+        // reduced inputs 
+        for (int dim=0; dim < a_ndim; ++dim) {
+            reduced_nd_index[dim] = in_index[dim];
+        }
+        auto increment_size = threadIdx.x;
+        for (int dim = a_ndim - 1; dim >= 0; --dim) {
+            // increment the index if this dim is being reduced
+            bool reduce_this_dim = false;
+            for (int ra=0; ra < nreduced_dim; ++ra) {
+                if (dim == reduced_axes[ra]) {
+                    reduce_this_dim = true;
+                    break;
+                }
+            }
+            if (reduce_this_dim) {
+                reduced_nd_index[dim] += increment_size;
+                if (reduced_nd_index[dim] < a_shape[dim]) {
+                    break;
+                } else {
+                    // The remainder might be multiples of dim sizes
+                    increment_size = reduced_nd_index[dim] / a_shape[dim];
+                    reduced_nd_index[dim] = reduced_nd_index[dim] % a_shape[dim];
+                }
+            }
+        }
+
+        // Iterate through the inputs to reduce to this output....
+        for (int64_t jj=tid; jj < reduction_factor; jj += blockDim.x) {
+            int64_t in_linear_index = 0;
+            for (int dim = 0; dim < a_ndim; ++dim) {
+                in_linear_index += reduced_nd_index[dim] * a_strides[dim];
+            }
+
+            // Read the input data and accumulate it to this threads accumulator
+            auto in_val = a_data[in_linear_index];
+            
+            // use a corrected sum (kahan sum) to preserve precision
+            if constexpr (is_floating<in_datatype>::value) {
+                auto y = in_val - sdata_c;
+                kahan(sdata[tid], y);
+                sdata_c = y;
+            } else {
+                // naive sum
+                sdata[tid] += in_val;
+            }
+            
+            // keep track of x^2 accumulation for stddev
+            auto x_square = in_val * in_val;
+            if constexpr (is_floating<in_datatype>::value) {
+                auto y2 = x_square - s2data_c;
+                kahan(s2data[tid], y2);
+                s2data_c = y2;
+            } else {
+                s2data[tid] += x_square;
+            }
+
+            // Increment nd_index for reduced dimensions
+            auto increment_size = blockDim.x;
+            for (int dim = a_ndim - 1; dim >= 0; --dim) {
+                // increment the index if this dim is being reduced
+                bool reduce_this_dim = false;
+                for (int ra=0; ra < nreduced_dim; ++ ra) {
+                    if (dim == reduced_axes[ra]) {
+                        reduce_this_dim = true;
+                        break;
+                    }
+                }
+                if (reduce_this_dim) {
+                    reduced_nd_index[dim] += increment_size;
+                    if (reduced_nd_index[dim] < a_shape[dim]) {
+                        break;
+                    } else {
+                        // The remainder might be multiples of dim sizes
+                        increment_size = reduced_nd_index[dim] / a_shape[dim];
+                        reduced_nd_index[dim] = reduced_nd_index[dim] % a_shape[dim];
+                    }
+                }
+            }
+        }
+
+        int64_t out_linear_index = 0;
+        for (int dim = 0; dim < mean_out_ndim; ++dim) {
+            out_linear_index += mean_out_index[dim] * mean_out_strides[dim];
+        }
+
+        // Normalize accumulated inputs as needed.
+        sdata[tid] /= reduction_factor;
+        s2data[tid] /= reduction_factor;
+        __syncthreads();
+        for (int s=blockDim.x/2; s > 0; s>>=1) {
+            if (tid < s) {
+                // __syncthreads();
+                // printf("(%i) reduced sum is sdata[%i] + sdata[%i]. (%f + %f)\n", tid, tid, tid+s, sdata[tid], sdata[tid+s]);
+                sdata[tid] += sdata[tid+s];
+                s2data[tid] += s2data[tid+s];
+            }
+            __syncthreads();
+        }
+        // Write the final accumulated value to global output
+        if (tid == 0) {
+            // out_data[out_linear_index] = static_cast<out_datatype>((s2data[0] - sdata[0]*sdata[0]));
+            // printf("E[X^2] = %f - E[X]^2 = %f\n", s2data[0], sdata[0]*sdata[0]);
+            auto diff = (s2data[0] - sdata[0]*sdata[0]);
+            diff = max((in_datatype)0, diff);
+            mean_out_data[out_linear_index] = static_cast<out_datatype>(sdata[0]);
+            stddev_out_data[out_linear_index] = static_cast<out_datatype>(sqrt(diff));
+        }
+
+        increment_size = gridDim.x;
+        // Increment out and in pointers to next non-reduced dims
+        for (int dim = mean_out_ndim - 1; dim >= 0; --dim) {
+            mean_out_index[dim] += increment_size;
+            if (mean_out_index[dim] < mean_out_shape[dim]) {
+                break;
+            } else {
+                increment_size = mean_out_index[dim] / mean_out_shape[dim];
+                mean_out_index[dim] = mean_out_index[dim] % mean_out_shape[dim];
+            }
+        }
+
+        increment_size = gridDim.x;
+        for (int dim = a_ndim - 1; dim >= 0; --dim) {
+            // increment the index if this dim is being reduced
+            bool reduce_this_dim = false;
+            for (int ra=0; ra < nreduced_dim; ++ra) {
+                if (dim == reduced_axes[ra]) {
+                    reduce_this_dim = true;
+                    break;
+                }
+            }
+            if (!reduce_this_dim) {
+                in_index[dim] += increment_size;
+                if (in_index[dim] < a_shape[dim]) {
+                    break;
+                } else {
+                    increment_size = in_index[dim] / a_shape[dim];
+                    in_index[dim] = in_index[dim] % a_shape[dim];
+                }
+            }
+        }
+    }
+}
+
+/**
+ * masked version
+ */
 template <typename out_datatype, typename in_datatype, reductiontype Op>
 __global__ void reduction_impl(out_datatype* out_data, int64_t* out_shape, int64_t* out_strides, int64_t out_ndim, int64_t out_numel,
                         in_datatype* a_data, int64_t* a_shape, int64_t* a_strides, int64_t a_ndim,
@@ -548,10 +752,229 @@ __global__ void reduction_impl(out_datatype* out_data, int64_t* out_shape, int64
     }
 }
 
-// comparison_reduction_impl<datatype, Reduction><<<num_blocks, block_size, smem_per_block>>>(out_data, thrust::raw_pointer_cast(dev_out_shape.data()), thrust::raw_pointer_cast(dev_out_strides.data()), dev_out_shape.size(), out_numel,
-//                                                         a_data, thrust::raw_pointer_cast(dev_a_shape.data()), thrust::raw_pointer_cast(dev_a_strides.data()), dev_a_shape.size(),
-//                                                         thrust::raw_pointer_cast(dev_reduced_axes.data()), dev_reduced_axes.size(), reduced_elements
-//                                                         );
+
+// // template <typename out_datatype, typename in_datatype, reductiontype Op>
+// __global__ void mean_stddev_impl(float* mean_out_data, int64_t* mean_out_shape, int64_t* mean_out_strides, int64_t mean_out_ndim, int64_t mean_out_numel,
+//                         float* stddev_out_data, int64_t* stddev_out_shape, int64_t* stddev_out_strides, int64_t stddev_out_ndim, int64_t stddev_out_numel,
+//                         float* a_data, int64_t* a_shape, int64_t* a_strides, int64_t a_ndim,
+//                         int64_t* reduced_axes, int64_t nreduced_dim, int64_t reduction_factor) {
+//     // A good primer on reduction kernels: https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
+
+
+
+// template <typename out_datatype, typename in_datatype, reductiontype Op>
+__global__ void mean_stddev_impl(float* mean_out_data, int64_t* mean_out_shape, int64_t* mean_out_strides, int64_t mean_out_ndim, int64_t mean_out_numel,
+                        float* stddev_out_data, int64_t* stddev_out_shape, int64_t* stddev_out_strides, int64_t stddev_out_ndim, int64_t stddev_out_numel,
+                        float* a_data, int64_t* a_shape, int64_t* a_strides, int64_t a_ndim,
+                        uint8_t* mask_data, int64_t* mask_shape, int64_t* mask_strides, int64_t mask_ndim,
+                        int64_t* reduced_axes, int64_t nreduced_dim, int64_t reduction_factor) {
+    // A good primer on reduction kernels: https://developer.download.nvidia.com/assets/cuda/files/reduction.pdf
+
+    using out_datatype = float;
+    using in_datatype = float;
+    using accumulator_type = float;
+    auto tid = threadIdx.x;
+    auto outer_workid = blockIdx.x;
+    auto outer_gridsize = gridDim.x;
+
+    // Assume we've been given shared memory with enough space for each thread
+    // to hold an accumulator of the in_datatype size (and one for x^2 if stddev or var)
+    // Break that shared memory up in to appropriate chunks easily indexed by smem
+    extern __shared__ char shared_memory[];
+    accumulator_type* sdata = reinterpret_cast<accumulator_type*>(shared_memory);
+    accumulator_type sdata_c = 0;
+    accumulator_type* s2data = sdata + blockDim.x;
+    accumulator_type s2data_c = 0;
+
+    int count_offset = blockDim.x;
+    count_offset = 2*blockDim.x;
+    uint32_t* scount = reinterpret_cast<uint32_t*>(sdata + count_offset);
+
+    int64_t out_index[MAX_NDIM] = {0};
+    int64_t in_index[MAX_NDIM] = {0};
+    int64_t reduced_nd_index[MAX_NDIM] = {0};
+
+    // Initialize ndindex per threadblock
+    auto flattened_work_item = outer_workid;
+    for (int dim = mean_out_ndim - 1; dim >= 0; --dim) {
+        out_index[dim] = flattened_work_item % mean_out_shape[dim];
+        flattened_work_item /= mean_out_shape[dim];
+    }
+    flattened_work_item = outer_workid;
+    for (int dim = a_ndim - 1; dim >= 0; --dim) {
+        bool reduce_this_dim = false;
+        for (int ra=0; ra < nreduced_dim; ++ra) {
+            if (dim == reduced_axes[ra]) {
+                reduce_this_dim = true;
+                break;
+            }
+        }
+        if (!reduce_this_dim) {
+            in_index[dim] = flattened_work_item % a_shape[dim];
+            flattened_work_item /= a_shape[dim];
+        }
+    }
+
+    auto numel = mean_out_numel;
+    for (int64_t i = outer_workid; i < numel; i+=outer_gridsize) {
+        // Reset accumulators
+        sdata[tid] = 0;
+        scount[tid] = 0;
+        s2data[tid] = 0;
+        // Deep copy the input index which is advancing over non-reduced inputs
+        // to reduced_nd_index which will be used in inner loop to advance through
+        // reduced inputs 
+        for (int dim=0; dim < a_ndim; ++dim) {
+            reduced_nd_index[dim] = in_index[dim];
+        }
+        auto increment_size = threadIdx.x;
+        for (int dim = a_ndim - 1; dim >= 0; --dim) {
+            // increment the index if this dim is being reduced
+            bool reduce_this_dim = false;
+            for (int ra=0; ra < nreduced_dim; ++ra) {
+                if (dim == reduced_axes[ra]) {
+                    reduce_this_dim = true;
+                    break;
+                }
+            }
+            if (reduce_this_dim) {
+                reduced_nd_index[dim] += increment_size;
+                if (reduced_nd_index[dim] < a_shape[dim]) {
+                    break;
+                } else {
+                    // The remainder might be multiples of dim sizes
+                    increment_size = reduced_nd_index[dim] / a_shape[dim];
+                    reduced_nd_index[dim] = reduced_nd_index[dim] % a_shape[dim];
+                }
+            }
+        }
+
+        // Iterate through the inputs to reduce to this output....
+        for (int64_t jj=tid; jj < reduction_factor; jj += blockDim.x) {
+            int64_t in_linear_index = 0;
+            int64_t mask_linear_index = 0;
+            for (int dim = 0; dim < a_ndim; ++dim) {
+                in_linear_index += reduced_nd_index[dim] * a_strides[dim];
+                mask_linear_index += reduced_nd_index[dim] * mask_strides[dim];
+            }
+
+            if (mask_data[mask_linear_index] == 0) {
+                scount[tid] += 1;
+
+                // Read the input data and accumulate it to this threads accumulator
+                auto in_val = a_data[in_linear_index];
+                
+                // use a corrected sum (kahan sum) to preserve precision
+                if constexpr (is_floating<in_datatype>::value) {
+                    auto y = in_val - sdata_c;
+                    kahan(sdata[tid], y);
+                    sdata_c = y;
+                } else {
+                    // naive sum
+                    sdata[tid] += in_val;
+                }
+                
+                // stddev and variance will also keep track of x^2 accumulation
+                auto x_square = in_val * in_val;
+                auto y2 = x_square - s2data_c;
+                kahan(s2data[tid], y2);
+                s2data_c = y2;
+
+            }
+
+            // Increment nd_index for reduced dimensions
+            auto increment_size = blockDim.x;
+            for (int dim = a_ndim - 1; dim >= 0; --dim) {
+                // increment the index if this dim is being reduced
+                bool reduce_this_dim = false;
+                for (int ra=0; ra < nreduced_dim; ++ ra) {
+                    if (dim == reduced_axes[ra]) {
+                        reduce_this_dim = true;
+                        break;
+                    }
+                }
+                if (reduce_this_dim) {
+                    reduced_nd_index[dim] += increment_size;
+                    if (reduced_nd_index[dim] < a_shape[dim]) {
+                        break;
+                    } else {
+                        // The remainder might be multiples of dim sizes
+                        increment_size = reduced_nd_index[dim] / a_shape[dim];
+                        reduced_nd_index[dim] = reduced_nd_index[dim] % a_shape[dim];
+                    }
+                }
+            }
+        }
+
+        int64_t out_linear_index = 0;
+        for (int dim = 0; dim < mean_out_ndim; ++dim) {
+            out_linear_index += out_index[dim] * mean_out_strides[dim];
+        }
+
+        __syncthreads();
+        for (int s=blockDim.x/2; s > 0; s>>=1) {
+            if (tid < s) {
+                // __syncthreads();
+                // printf("(%i) reduced sum is sdata[%i] + sdata[%i]. (%f + %f)\n", tid, tid, tid+s, sdata[tid], sdata[tid+s]);
+                sdata[tid] += sdata[tid+s];
+                scount[tid] += scount[tid+s];
+                s2data[tid] += s2data[tid+s];
+            }
+            __syncthreads();
+        }
+        // Write the final accumulated value to global output
+        if (tid == 0) {
+            // TODO: guard against scount == 0
+
+                sdata[0] /= scount[0];
+                s2data[0] /= scount[0];
+                // out_data[out_linear_index] = static_cast<out_datatype>((s2data[0] - sdata[0]*sdata[0]));
+                // printf("E[X^2] = %f - E[X]^2 = %f\n", s2data[0], sdata[0]*sdata[0]);
+                auto diff = (s2data[0] - sdata[0]*sdata[0]);
+                diff = max((in_datatype)0, diff);
+                mean_out_data[out_linear_index] = static_cast<out_datatype>(sdata[0]);
+                stddev_out_data[out_linear_index] = static_cast<out_datatype>(sqrt(diff));
+        }
+
+        increment_size = gridDim.x;
+        // Increment out and in pointers to next non-reduced dims
+        for (int dim = mean_out_ndim - 1; dim >= 0; --dim) {
+            out_index[dim] += increment_size;
+            if (out_index[dim] < mean_out_shape[dim]) {
+                break;
+            } else {
+                increment_size = out_index[dim] / mean_out_shape[dim];
+                out_index[dim] = out_index[dim] % mean_out_shape[dim];
+            }
+        }
+
+        increment_size = gridDim.x;
+        for (int dim = a_ndim - 1; dim >= 0; --dim) {
+            // increment the index if this dim is being reduced
+            bool reduce_this_dim = false;
+            for (int ra=0; ra < nreduced_dim; ++ra) {
+                if (dim == reduced_axes[ra]) {
+                    reduce_this_dim = true;
+                    break;
+                }
+            }
+            if (!reduce_this_dim) {
+                in_index[dim] += increment_size;
+                if (in_index[dim] < a_shape[dim]) {
+                    break;
+                } else {
+                    increment_size = in_index[dim] / a_shape[dim];
+                    in_index[dim] = in_index[dim] % a_shape[dim];
+                }
+            }
+        }
+    }
+}
+
+
+/**
+ * max,...
+ */
 template <typename datatype, comparison_reductiontype Op>
 __global__ void comparison_reduction_impl(datatype* out_data, int64_t* out_shape, int64_t* out_strides, int64_t out_ndim, int64_t out_numel,
                         datatype* a_data, int64_t* a_shape, int64_t* a_strides, int64_t a_ndim,
@@ -866,7 +1289,7 @@ struct statistical_launch_wrapper {
         auto       out_data  = out.data_ptr<out_datatype>();
         const auto out_offset = out.offsets();
         const auto out_shape = out.shape();
-        const auto out_strides = out.strides();        
+        const auto out_strides = out.strides();
 
         thrust::device_vector<int64_t> dev_out_shape(out_shape.begin(), out_shape.end());
         thrust::device_vector<int64_t> dev_out_strides(out_strides.begin(), out_strides.end());
@@ -942,7 +1365,7 @@ struct comparison_reduction_launch_wrapper {
         auto       out_data  = out.data_ptr<datatype>();
         const auto out_offset = out.offsets();
         const auto out_shape = out.shape();
-        const auto out_strides = out.strides();        
+        const auto out_strides = out.strides();
 
         thrust::device_vector<int64_t> dev_out_shape(out_shape.begin(), out_shape.end());
         thrust::device_vector<int64_t> dev_out_strides(out_strides.begin(), out_strides.end());
@@ -996,6 +1419,157 @@ struct comparison_reduction_launch_wrapper {
 };
 
 
+std::pair<ndarray, ndarray> mean_stddev_wrapper(ndarray mean_out, ndarray stddev_out, const ndarray &a, std::vector<int64_t> reduced_axes) {
+    // This is mostly a copy of the template stuct of statistical_reduction_wrapper but uses a fixed float dtype and two output arrays
+    using out_datatype = float;
+    using in_datatype = float;
+    auto       mean_out_data  = mean_out.data_ptr<out_datatype>();
+    const auto mean_out_offset = mean_out.offsets();
+    const auto mean_out_shape = mean_out.shape();
+    const auto mean_out_strides = mean_out.strides();        
+
+    auto       stddev_out_data  = stddev_out.data_ptr<out_datatype>();
+    const auto stddev_out_offset = stddev_out.offsets();
+    const auto stddev_out_shape = stddev_out.shape();
+    const auto stddev_out_strides = stddev_out.strides();        
+
+    thrust::device_vector<int64_t> dev_out_shape(mean_out_shape.begin(), mean_out_shape.end());
+    thrust::device_vector<int64_t> dev_out_strides(mean_out_strides.begin(), mean_out_strides.end());
+
+    auto a_shape = a.shape();
+    auto a_data = a.data_ptr<in_datatype>();
+    const auto a_offset  = a.offsets();
+    const auto a_strides = a.strides();
+
+    thrust::device_vector<int64_t> dev_a_shape(a_shape.begin(), a_shape.end());
+    thrust::device_vector<int64_t> dev_a_strides(a_strides.begin(), a_strides.end());
+
+    int64_t reduced_elements = 1;
+    for (auto &d : reduced_axes) {
+        reduced_elements *= a_shape[d];
+    }
+    thrust::device_vector<int64_t> dev_reduced_axes(reduced_axes.begin(), reduced_axes.end());
+
+    cudaDeviceProp props;
+    cudaGetDeviceProperties(&props, a.device().device_id);
+
+    int block_size = 512;
+    int required_smem_per_thread = sizeof(in_datatype);
+    // need to keep an E[X^2] which will take double the smem
+    required_smem_per_thread += sizeof(in_datatype);
+    if (reduced_elements < block_size) {
+        // Reduce to a block size that is a power of 2 but less than number of items that need reducing
+        block_size = reduced_elements | (reduced_elements >> 1);
+        block_size |= (block_size >> 2);
+        block_size |= (block_size >> 4);
+        block_size |= (block_size >> 8);
+        block_size |= (block_size >> 16);
+        block_size = block_size - (block_size >> 1);
+    }
+    auto out_numel = mean_out.numel();
+    // TODO (low prio): find a good maximum # blocks
+    int num_blocks = std::min<int64_t>(1024, out_numel);
+    int smem_per_block = required_smem_per_thread * block_size;
+    // TODO: Check we have enough smem
+    smem_per_block *= 2; 
+    mean_stddev_impl<<<num_blocks, block_size, smem_per_block>>>(mean_out_data, thrust::raw_pointer_cast(dev_out_shape.data()), thrust::raw_pointer_cast(dev_out_strides.data()), dev_out_shape.size(), out_numel,
+                                                            stddev_out_data, thrust::raw_pointer_cast(dev_out_shape.data()), thrust::raw_pointer_cast(dev_out_strides.data()), dev_out_shape.size(), out_numel,
+                                                            a_data, thrust::raw_pointer_cast(dev_a_shape.data()), thrust::raw_pointer_cast(dev_a_strides.data()), dev_a_shape.size(),
+                                                            thrust::raw_pointer_cast(dev_reduced_axes.data()), dev_reduced_axes.size(), reduced_elements
+                                                            );
+    // auto launch_ret = cudaDeviceSynchronize();
+    // auto kernel_ret = cudaGetLastError();
+    // if (launch_ret != cudaSuccess) {
+    //     fmt::print("cuda launch got error {} ({})\n", launch_ret, cudaGetErrorString(launch_ret));
+    // }
+    // if (kernel_ret != cudaSuccess) {
+    //     fmt::print("cuda launch got error {} ({})\n", kernel_ret, cudaGetErrorString(kernel_ret));
+    // }
+
+    return std::make_pair(mean_out, stddev_out);
+}
+
+
+std::pair<ndarray, ndarray> mean_stddev_wrapper(ndarray mean_out, ndarray stddev_out, const ndarray &a, const ndarray &mask, std::vector<int64_t> reduced_axes) {
+    // This is mostly a copy of the template stuct of statistical_reduction_wrapper but uses a fixed float dtype and two output arrays
+    using out_datatype = float;
+    using in_datatype = float;
+    auto       mean_out_data  = mean_out.data_ptr<out_datatype>();
+    const auto mean_out_offset = mean_out.offsets();
+    const auto mean_out_shape = mean_out.shape();
+    const auto mean_out_strides = mean_out.strides();
+
+    auto       stddev_out_data  = stddev_out.data_ptr<out_datatype>();
+    const auto stddev_out_offset = stddev_out.offsets();
+    const auto stddev_out_shape = stddev_out.shape();
+    const auto stddev_out_strides = stddev_out.strides();
+
+    thrust::device_vector<int64_t> dev_out_shape(mean_out_shape.begin(), mean_out_shape.end());
+    thrust::device_vector<int64_t> dev_out_strides(mean_out_strides.begin(), mean_out_strides.end());
+
+    auto a_shape = a.shape();
+    auto a_data = a.data_ptr<in_datatype>();
+    const auto a_offset  = a.offsets();
+    const auto a_strides = a.strides();
+
+    thrust::device_vector<int64_t> dev_a_shape(a_shape.begin(), a_shape.end());
+    thrust::device_vector<int64_t> dev_a_strides(a_strides.begin(), a_strides.end());
+
+    auto mask_shape = mask.shape();
+    auto mask_data = mask.data_ptr<uint8_t>();
+    const auto mask_offset   = mask.offsets();
+    const auto mask_strides  = mask.strides();
+
+    thrust::device_vector<int64_t> dev_mask_shape(mask_shape.begin(), mask_shape.end());
+    thrust::device_vector<int64_t> dev_mask_strides(mask_strides.begin(), mask_strides.end());
+
+    int64_t reduced_elements = 1;
+    for (auto &d : reduced_axes) {
+        reduced_elements *= a_shape[d];
+    }
+    thrust::device_vector<int64_t> dev_reduced_axes(reduced_axes.begin(), reduced_axes.end());
+
+    cudaDeviceProp props;
+    cudaGetDeviceProperties(&props, a.device().device_id);
+
+    int block_size = 512;
+    int required_smem_per_thread = sizeof(in_datatype) +4; // 4B for the mask count
+    // need to keep an E[X^2] which will take double the smem
+    required_smem_per_thread += sizeof(in_datatype);
+    if (reduced_elements < block_size) {
+        // Reduce to a block size that is a power of 2 but less than number of items that need reducing
+        block_size = reduced_elements | (reduced_elements >> 1);
+        block_size |= (block_size >> 2);
+        block_size |= (block_size >> 4);
+        block_size |= (block_size >> 8);
+        block_size |= (block_size >> 16);
+        block_size = block_size - (block_size >> 1);
+    }
+    auto out_numel = mean_out.numel();
+    // TODO (low prio): find a good maximum # blocks
+    int num_blocks = std::min<int64_t>(1024, out_numel);
+    int smem_per_block = required_smem_per_thread * block_size;
+    // TODO: Check we have enough smem
+    smem_per_block *= 2; 
+    mean_stddev_impl<<<num_blocks, block_size, smem_per_block>>>(mean_out_data, thrust::raw_pointer_cast(dev_out_shape.data()), thrust::raw_pointer_cast(dev_out_strides.data()), dev_out_shape.size(), out_numel,
+                                                            stddev_out_data, thrust::raw_pointer_cast(dev_out_shape.data()), thrust::raw_pointer_cast(dev_out_strides.data()), dev_out_shape.size(), out_numel,
+                                                            a_data, thrust::raw_pointer_cast(dev_a_shape.data()), thrust::raw_pointer_cast(dev_a_strides.data()), dev_a_shape.size(),
+                                                            mask_data, thrust::raw_pointer_cast(dev_mask_shape.data()), thrust::raw_pointer_cast(dev_mask_strides.data()), dev_mask_shape.size(),
+                                                            thrust::raw_pointer_cast(dev_reduced_axes.data()), dev_reduced_axes.size(), reduced_elements
+                                                            );
+    // auto launch_ret = cudaDeviceSynchronize();
+    // auto kernel_ret = cudaGetLastError();
+    // if (launch_ret != cudaSuccess) {
+    //     fmt::print("cuda launch got error {} ({})\n", launch_ret, cudaGetErrorString(launch_ret));
+    // }
+    // if (kernel_ret != cudaSuccess) {
+    //     fmt::print("cuda launch got error {} ({})\n", kernel_ret, cudaGetErrorString(kernel_ret));
+    // }
+
+    return std::make_pair(mean_out, stddev_out);
+}
+
+
 ndarray bland::cuda::max(const ndarray &a, ndarray &out, std::vector<int64_t> reduced_axes) {
     return dispatch_new4<comparison_reduction_launch_wrapper<comparison_reductiontype::max>>(out, a, reduced_axes);
 }
@@ -1023,6 +1597,14 @@ ndarray bland::cuda::stddev(const ndarray &a, ndarray &out, std::vector<int64_t>
 
 ndarray bland::cuda::masked_stddev(const ndarray &a, const ndarray &mask, ndarray &out, std::vector<int64_t> reduced_axes) {
     return dispatch_new<statistical_launch_wrapper<reductiontype::stddev>>(out, a, mask, reduced_axes);
+}
+
+std::pair<ndarray, ndarray> bland::cuda::mean_stddev(const ndarray &a, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> reduced_axes) {
+    return mean_stddev_wrapper(out_mean, out_stddev, a, reduced_axes);
+}
+
+std::pair<ndarray, ndarray> bland::cuda::masked_mean_stddev(const ndarray &a, const ndarray &mask, ndarray &out_mean, ndarray &out_stddev, std::vector<int64_t> reduced_axes) {
+    return mean_stddev_wrapper(out_mean, out_stddev, a, mask, reduced_axes);
 }
 
 ndarray bland::cuda::var(const ndarray &a, ndarray &out, std::vector<int64_t> reduced_axes) {

--- a/bland/python/CMakeLists.txt
+++ b/bland/python/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(pybland_header
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-nanobind_add_module(pybland NB_DOMAIN bland pybland.cpp)
+nanobind_add_module(pybland pybland.cpp)
 target_link_libraries(pybland PUBLIC bland)
 
 # Check if PY_BUILD_CMAKE_MODULE_NAME is defined

--- a/bland/python/pybland.hpp
+++ b/bland/python/pybland.hpp
@@ -6,6 +6,7 @@
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
 #include <nanobind/stl/vector.h>
+#include <nanobind/stl/pair.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -232,6 +233,10 @@ void bind_pybland(nb::module_ m) {
         return bland::mean(nb_to_bland(a), axes);
     }, "a"_a, "axes"_a=std::vector<int64_t>{});
 
+    m.def("masked_mean", [](nb::ndarray<> a, nb::ndarray<> m, std::vector<int64_t>axes={}) {
+        return bland::masked_mean(nb_to_bland(a), nb_to_bland(m), axes);
+    }, "a"_a, "m"_a, "axes"_a=std::vector<int64_t>{});
+
     m.def("median", [](nb::ndarray<> a, std::vector<int64_t>axes={}) {
         return bland::median(nb_to_bland(a), axes);
     }, "a"_a, "axes"_a=std::vector<int64_t>{});
@@ -240,9 +245,21 @@ void bind_pybland(nb::module_ m) {
         return bland::stddev(nb_to_bland(a), axes);
     }, "a"_a, "axes"_a=std::vector<int64_t>{});
 
+    m.def("masked_stddev", [](nb::ndarray<> a, nb::ndarray<> m, std::vector<int64_t>axes={}) {
+        return bland::masked_stddev(nb_to_bland(a), nb_to_bland(m), axes);
+    }, "a"_a, "m"_a, "axes"_a=std::vector<int64_t>{});
+
     m.def("var", [](nb::ndarray<> a, std::vector<int64_t>axes={}) {
         return bland::var(nb_to_bland(a), axes);
     }, "a"_a, "axes"_a=std::vector<int64_t>{});
+
+    m.def("mean_stddev", [](nb::ndarray<> a, std::vector<int64_t>axes={}) {
+        return bland::mean_stddev(nb_to_bland(a), axes);
+    }, "a"_a, "axes"_a=std::vector<int64_t>{});
+
+    m.def("masked_mean_stddev", [](nb::ndarray<> a, nb::ndarray<> m, std::vector<int64_t>axes={}) {
+        return bland::masked_mean_stddev(nb_to_bland(a), nb_to_bland(m), axes);
+    }, "a"_a, "m"_a, "axes"_a=std::vector<int64_t>{});
 
     m.def("standardized_moment", [](nb::ndarray<> a, int degree, std::vector<int64_t>axes={}) {
         return bland::standardized_moment(nb_to_bland(a), degree, axes);

--- a/bliss/bliss_find_hits.cpp
+++ b/bliss/bliss_find_hits.cpp
@@ -10,6 +10,7 @@
 #include <drift_search/integrate_drifts.hpp>
 #include <flaggers/filter_rolloff.hpp>
 #include <flaggers/magnitude.hpp>
+#include <flaggers/sigmaclip.hpp>
 #include <flaggers/spectral_kurtosis.hpp>
 #include <file_types/hits_file.hpp>
 
@@ -101,6 +102,7 @@ int main(int argc, char *argv[]) {
 
     pipeline_object = bliss::flag_filter_rolloff(pipeline_object, 0.25);
     pipeline_object = bliss::flag_spectral_kurtosis(pipeline_object, 0.1, 25);
+    pipeline_object = bliss::flag_sigmaclip(pipeline_object, 3, 5, 5);
 
     pipeline_object = bliss::estimate_noise_power(
             pipeline_object,

--- a/bliss/estimators/include/estimators/pyestimators.hpp
+++ b/bliss/estimators/include/estimators/pyestimators.hpp
@@ -21,12 +21,13 @@ void bind_pyestimators(nb::module_ m) {
           "spectrum_grid"_a,
           "N"_a,
           "M"_a,
-          "d"_a = 1,
+          "d"_a = 2,
           "Compute spectral kurtosis of the given spectra");
 
     m.def("estimate_spectral_kurtosis",
-          nb::overload_cast<bliss::coarse_channel &>(&bliss::estimate_spectral_kurtosis),
+          nb::overload_cast<bliss::coarse_channel &, float>(&bliss::estimate_spectral_kurtosis),
           "fil_data"_a,
+          "d"_a = 2,
           "Compute spectral kurtosis of the given filterbank data");
 
     nb::enum_<bliss::noise_power_estimator>(m, "noise_power_estimator")

--- a/bliss/estimators/include/estimators/spectral_kurtosis.hpp
+++ b/bliss/estimators/include/estimators/spectral_kurtosis.hpp
@@ -23,10 +23,9 @@ namespace bliss {
  * "Radio Frequency Interference Excision Using Spectral-Domain Statistics"
  *
  */
-[[nodiscard]] bland::ndarray estimate_spectral_kurtosis(const bland::ndarray &spectrum_grid, int32_t N, int32_t M, float d = 1.0);
+[[nodiscard]] bland::ndarray estimate_spectral_kurtosis(const bland::ndarray &spectrum_grid, int32_t N, int32_t M, float d = 2.0);
 
-[[nodiscard]] bland::ndarray estimate_spectral_kurtosis(coarse_channel &cc_data);
+[[nodiscard]] bland::ndarray estimate_spectral_kurtosis(coarse_channel &cc_data, float d = 2.0);
 
-// bland::ndarray estimate_spectral_kurtosis(scan &fil_data);
 
 } // namespace bliss

--- a/bliss/estimators/spectral_kurtosis.cpp
+++ b/bliss/estimators/spectral_kurtosis.cpp
@@ -7,37 +7,23 @@
 using namespace bliss;
 
 bland::ndarray bliss::estimate_spectral_kurtosis(const bland::ndarray &spectrum_grid, int32_t N, int32_t M, float d) {
-    fmt::print("INFO: spec kurtosis with M={} and N={}\n", M, N);
+    fmt::print("INFO: spec kurtosis with M={}, N={}, d={}\n", M, N, d);
     auto s1 = bland::square(bland::sum(spectrum_grid, {0}));
     auto s2 = bland::sum(bland::square(spectrum_grid), {0});
     auto sk = ((M * N * d + 1) / (M - 1)) * (M * (s2 / s1) - 1);
     return sk;
 }
 
-bland::ndarray bliss::estimate_spectral_kurtosis(coarse_channel &cc_data) {
+bland::ndarray bliss::estimate_spectral_kurtosis(coarse_channel &cc_data, float d) {
     const bland::ndarray spectrum_grid = cc_data.data();
 
     // 1. Compute spectral kurtosis along each channel
     auto M  = spectrum_grid.size(0);
-    auto d  = 1;
     auto Fs = std::abs(1.0 / (1e6 * cc_data.foff()));
     auto N  = std::round(cc_data.tsamp() / Fs);
 
-    auto sk = estimate_spectral_kurtosis(spectrum_grid, N, M, 1.0);
+    auto sk = estimate_spectral_kurtosis(spectrum_grid, N, M, d);
 
     return sk;
 }
 
-// bland::ndarray bliss::estimate_spectral_kurtosis(scan &fil_data) {
-//     const auto spectrum_grid = fil_data.data();
-
-//     // 1. Compute spectral kurtosis along each channel
-//     auto M  = spectrum_grid.size(0);
-//     auto d  = 1;
-//     auto Fs = std::abs(1.0 / (1e6 * fil_data.foff()));
-//     auto N  = std::round(fil_data.tsamp() / Fs);
-
-//     auto sk = estimate_spectral_kurtosis(spectrum_grid, N, M, 1.0);
-
-//     return sk;
-// }

--- a/bliss/flaggers/CMakeLists.txt
+++ b/bliss/flaggers/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(flaggers
     filter_rolloff.cpp
     magnitude.cpp
+    sigmaclip.cpp
     spectral_kurtosis.cpp
 )
 

--- a/bliss/flaggers/include/flaggers/pyflaggers.hpp
+++ b/bliss/flaggers/include/flaggers/pyflaggers.hpp
@@ -21,32 +21,36 @@ void bind_pyflaggers(nb::module_ m) {
 
     // Spectral Kurtosis
     m.def("flag_spectral_kurtosis",
-          nb::overload_cast<bliss::coarse_channel, float, float>(&bliss::flag_spectral_kurtosis),
+          nb::overload_cast<bliss::coarse_channel, float, float, float>(&bliss::flag_spectral_kurtosis),
           "cc_data"_a,
           "lower_threshold"_a,
           "upper_threshold"_a,
+          "d"_a = 2.0,
           "return a masked copy of scan where estimate_spectral_kurtosis indicates non-gaussian samples");
 
     m.def("flag_spectral_kurtosis",
-          nb::overload_cast<bliss::scan, float, float>(&bliss::flag_spectral_kurtosis),
+          nb::overload_cast<bliss::scan, float, float, float>(&bliss::flag_spectral_kurtosis),
           "scan"_a,
           "lower_threshold"_a,
           "upper_threshold"_a,
+          "d"_a = 2.0,
           "return a masked copy of scan where estimate_spectral_kurtosis indicates non-gaussian samples");
 
     m.def("flag_spectral_kurtosis",
-          nb::overload_cast<bliss::observation_target, float, float>(&bliss::flag_spectral_kurtosis),
+          nb::overload_cast<bliss::observation_target, float, float, float>(&bliss::flag_spectral_kurtosis),
           "observation"_a,
           "lower_threshold"_a,
           "upper_threshold"_a,
+          "d"_a = 2.0,
           "return an observation target where all scan have non-gaussian samples flagged by spectral "
           "kurtosis");
 
     m.def("flag_spectral_kurtosis",
-          nb::overload_cast<bliss::cadence, float, float>(&bliss::flag_spectral_kurtosis),
+          nb::overload_cast<bliss::cadence, float, float, float>(&bliss::flag_spectral_kurtosis),
           "cadence"_a,
           "lower_threshold"_a,
           "upper_threshold"_a,
+          "d"_a=2.0,
           "return a cadence with non-gaussian samples are flagged");
 
     // Rolloff

--- a/bliss/flaggers/include/flaggers/sigmaclip.hpp
+++ b/bliss/flaggers/include/flaggers/sigmaclip.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <core/coarse_channel.hpp>
+#include <core/scan.hpp>
+#include <core/cadence.hpp>
+
+namespace bliss {
+
+/**
+ * return a mask with flags set for grid elements which have magnitude above the defined threshold
+ * 
+*/
+bland::ndarray flag_sigmaclip(const bland::ndarray &data, int max_iter=5, float low=5.0f, float high=5.0f);
+
+/**
+ * return a masked copy of fb_data where the coarse_channel.data() is above the given threshold
+ * 
+*/
+coarse_channel flag_sigmaclip(coarse_channel fb_data, int max_iter=5, float low=5.0f, float high=5.0f);
+
+/**
+ * return a masked copy of fb_data where the scan.data() is above the given threshold
+ * 
+*/
+scan flag_sigmaclip(scan fb_data, int max_iter=5, float low=5.0f, float high=5.0f);
+
+/**
+ * return a masked copy of fb_data where the scan.data() is above the given threshold
+ * 
+*/
+observation_target flag_sigmaclip(observation_target target, int max_iter=5, float low=5.0f, float high=5.0f);
+
+/**
+ * return a masked copy of fb_data where the scan.data() is above the given threshold
+ * 
+*/
+cadence flag_sigmaclip(cadence cadence_data, int max_iter=5, float low=5.0f, float high=5.0f);
+
+
+}

--- a/bliss/flaggers/include/flaggers/spectral_kurtosis.hpp
+++ b/bliss/flaggers/include/flaggers/spectral_kurtosis.hpp
@@ -15,7 +15,7 @@ namespace bliss {
  * 
  * SK = (M N d + 1)/(M-1) * (M S_2 / S_1^2 -1)
  * 
- * d is 1
+ * d is a parameter of the gamma function used to describe the power spectrum
  * N is the number of spectrograms already averaged per spectra we receive
  * M is the number of spectra in this population to estimate kurtosis over (commonly 8, 16, or 32)
  * 
@@ -25,12 +25,12 @@ namespace bliss {
  * The non-averaged estimator (N=1) and background derivation can be found in
  * "Radio Frequency Interference Excision Using Spectral-Domain Statistics"
 */
-bland::ndarray flag_spectral_kurtosis(const bland::ndarray &data, int64_t N, int64_t M, float d, float lower_threshold, float upper_threshold);
+bland::ndarray flag_spectral_kurtosis(const bland::ndarray &data, int64_t N, int64_t M, float d=2, float lower_threshold=0.1, float upper_threshold=10);
 
 /**
  * Flag the filterbank data based on spectral kurtosis bounds and return the flagged filterbank
 */
-coarse_channel flag_spectral_kurtosis(coarse_channel channel_data, float lower_threshold=0.05f, float upper_threshold=0.05f);
+coarse_channel flag_spectral_kurtosis(coarse_channel channel_data, float lower_threshold=0.05f, float upper_threshold=0.05f, float d=2);
 
 /**
  * Flag the filterbank data based on spectral kurtosis bounds and return the flagged filterbank
@@ -38,16 +38,16 @@ coarse_channel flag_spectral_kurtosis(coarse_channel channel_data, float lower_t
  * TODO: make this work on *all* coarse channels in a filterbank, it might be useful to
  * defer computing perhaps with a future 
 */
-scan flag_spectral_kurtosis(scan fb_data, float lower_threshold=0.05f, float upper_threshold=0.05f);
+scan flag_spectral_kurtosis(scan fb_data, float lower_threshold=0.05f, float upper_threshold=0.05f, float d=2);
 
 /**
  * Flag all filterbanks in an observation target
 */
-observation_target flag_spectral_kurtosis(observation_target observations, float lower_threshold, float upper_threshold);
+observation_target flag_spectral_kurtosis(observation_target observations, float lower_threshold, float upper_threshold, float d=2);
 
 /**
  * Flag all filterbanks in the cadence with given SK estimate
 */
-cadence flag_spectral_kurtosis(cadence cadence_data, float lower_threshold=0.05f, float upper_threshold=0.05f);
+cadence flag_spectral_kurtosis(cadence cadence_data, float lower_threshold=0.05f, float upper_threshold=0.05f, float d=2);
 
 } // namespace bliss

--- a/bliss/flaggers/include/flaggers/spectral_kurtosis.hpp
+++ b/bliss/flaggers/include/flaggers/spectral_kurtosis.hpp
@@ -1,6 +1,6 @@
-
 #pragma once
 
+#include <core/coarse_channel.hpp>
 #include <core/scan.hpp>
 #include <core/cadence.hpp>
 
@@ -48,6 +48,6 @@ observation_target flag_spectral_kurtosis(observation_target observations, float
 /**
  * Flag all filterbanks in the cadence with given SK estimate
 */
-cadence flag_spectral_kurtosis(cadence fb_data, float lower_threshold=0.05f, float upper_threshold=0.05f);
+cadence flag_spectral_kurtosis(cadence cadence_data, float lower_threshold=0.05f, float upper_threshold=0.05f);
 
 } // namespace bliss

--- a/bliss/flaggers/sigmaclip.cpp
+++ b/bliss/flaggers/sigmaclip.cpp
@@ -1,0 +1,75 @@
+#include <flaggers/sigmaclip.hpp>
+
+#include <core/flag_values.hpp>
+
+#include <bland/ops/ops.hpp>
+
+#include <fmt/core.h>
+
+using namespace bliss;
+
+bland::ndarray bliss::flag_sigmaclip(const bland::ndarray &data, int max_iter, float low, float high) {
+
+    constexpr float eps = 1e-6;
+    auto            rfi = bland::zeros(data.shape(), data.dtype(), data.device());
+
+    auto [mean, stddev] = bland::masked_mean_stddev(data, rfi);
+    for (int iter = 0; iter < max_iter; ++iter) {
+        // fmt::print("iter {}:  mean={}    std={}\n", iter, mean.scalarize<float>(), stddev.scalarize<float>());
+        rfi = (data < (mean - stddev * low)) + (data > (mean + stddev * high));
+
+        auto [new_mean, new_std] = bland::masked_mean_stddev(data, rfi);
+        if (std::abs((new_mean - mean).scalarize<float>()) < eps &&
+            std::abs((new_std - stddev).scalarize<float>()) < eps) {
+            break;
+        } else {
+            mean   = new_mean;
+            stddev = new_std;
+        }
+    }
+
+    return rfi * static_cast<uint8_t>(flag_values::sigma_clip);
+}
+
+coarse_channel bliss::flag_sigmaclip(coarse_channel cc_data, int max_iter, float low, float high) {
+    auto cc_ptr = std::make_shared <coarse_channel>(cc_data);
+
+    auto deferred_accumulated_rfi = bland::ndarray_deferred([cc_dat = cc_ptr, max_iter, low, high]() {
+        bland::ndarray spectrum_grid = cc_dat->data();
+        bland::ndarray rfi_flags     = cc_dat->mask();
+
+        // 2. Generate SK flag
+        auto rfi = flag_sigmaclip(spectrum_grid, max_iter, low, high);
+
+        auto accumulated_rfi = rfi_flags + rfi; // a | operator would be more appropriate
+        return accumulated_rfi;
+    });
+
+    // 3. Store back accumulated rfi
+    cc_data.set_mask(deferred_accumulated_rfi);
+
+    return cc_data;
+}
+
+scan bliss::flag_sigmaclip(scan fil_data, int max_iter, float low, float high) {
+    auto number_coarse_channels = fil_data.get_number_coarse_channels();
+    for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
+        auto cc = fil_data.read_coarse_channel(cc_index);
+        *cc     = flag_sigmaclip(*cc, max_iter, low, high);
+    }
+    return fil_data;
+}
+
+observation_target bliss::flag_sigmaclip(observation_target observations, int max_iter, float low, float high) {
+    for (auto &filterbank : observations._scans) {
+        filterbank = flag_sigmaclip(filterbank, max_iter, low, high);
+    }
+    return observations;
+}
+
+cadence bliss::flag_sigmaclip(cadence observations, int max_iter, float low, float high) {
+    for (auto &observation : observations._observations) {
+        observation = flag_sigmaclip(observation, max_iter, low, high);
+    }
+    return observations;
+}

--- a/bliss/flaggers/spectral_kurtosis.cpp
+++ b/bliss/flaggers/spectral_kurtosis.cpp
@@ -27,17 +27,16 @@ bland::ndarray bliss::flag_spectral_kurtosis(const bland::ndarray &data,
     return rfi;
 }
 
-coarse_channel bliss::flag_spectral_kurtosis(coarse_channel cc_data, float lower_threshold, float upper_threshold) {
+coarse_channel bliss::flag_spectral_kurtosis(coarse_channel cc_data, float lower_threshold, float upper_threshold, float d) {
 
     auto cc_ptr = std::make_shared<coarse_channel>(cc_data);
 
-    auto deferred_accumulated_rfi = bland::ndarray_deferred([cc_data = cc_ptr, lower_threshold, upper_threshold]() {
+    auto deferred_accumulated_rfi = bland::ndarray_deferred([cc_data = cc_ptr, lower_threshold, upper_threshold, d]() {
         bland::ndarray spectrum_grid = cc_data->data();
         bland::ndarray rfi_flags     = cc_data->mask();
 
         // 1. Compute params for SK estimate
         auto M  = spectrum_grid.size(0);
-        auto d  = 1;
         auto Fs = std::abs(1.0 / (1e6 * cc_data->foff()));
         auto N  = std::round(cc_data->tsamp() / Fs);
 
@@ -54,26 +53,26 @@ coarse_channel bliss::flag_spectral_kurtosis(coarse_channel cc_data, float lower
     return cc_data;
 }
 
-scan bliss::flag_spectral_kurtosis(scan fil_data, float lower_threshold, float upper_threshold) {
+scan bliss::flag_spectral_kurtosis(scan fil_data, float lower_threshold, float upper_threshold, float d) {
     auto number_coarse_channels = fil_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
         auto cc = fil_data.read_coarse_channel(cc_index);
-        *cc     = flag_spectral_kurtosis(*cc, lower_threshold, upper_threshold);
+        *cc     = flag_spectral_kurtosis(*cc, lower_threshold, upper_threshold, d);
     }
     return fil_data;
 }
 
 observation_target
-bliss::flag_spectral_kurtosis(observation_target observations, float lower_threshold, float upper_threshold) {
+bliss::flag_spectral_kurtosis(observation_target observations, float lower_threshold, float upper_threshold, float d) {
     for (auto &filterbank : observations._scans) {
-        filterbank = flag_spectral_kurtosis(filterbank, lower_threshold, upper_threshold);
+        filterbank = flag_spectral_kurtosis(filterbank, lower_threshold, upper_threshold, d);
     }
     return observations;
 }
 
-cadence bliss::flag_spectral_kurtosis(cadence observations, float lower_threshold, float upper_threshold) {
+cadence bliss::flag_spectral_kurtosis(cadence observations, float lower_threshold, float upper_threshold, float d) {
     for (auto &observation : observations._observations) {
-        observation = flag_spectral_kurtosis(observation, lower_threshold, upper_threshold);
+        observation = flag_spectral_kurtosis(observation, lower_threshold, upper_threshold, d);
     }
     return observations;
 }

--- a/bliss/flaggers/spectral_kurtosis.cpp
+++ b/bliss/flaggers/spectral_kurtosis.cpp
@@ -1,12 +1,14 @@
-
-#include <core/flag_values.hpp>
 #include <flaggers/spectral_kurtosis.hpp>
+
 #include <estimators/spectral_kurtosis.hpp>
+#include <core/flag_values.hpp>
 
 #include <bland/ops/ops.hpp>
 
-#include <fmt/core.h>
-#include <fmt/ranges.h>
+// #include <fmt/core.h>
+// #include <fmt/ranges.h>
+
+#include <cmath> // std::round
 
 using namespace bliss;
 
@@ -25,12 +27,10 @@ bland::ndarray bliss::flag_spectral_kurtosis(const bland::ndarray &data,
     return rfi;
 }
 
-// bland::ndarray_deferred bliss::flag_spectral_kurtosis(const bland::ndarray_deferred &data)
-
 coarse_channel bliss::flag_spectral_kurtosis(coarse_channel cc_data, float lower_threshold, float upper_threshold) {
 
     auto cc_ptr = std::make_shared<coarse_channel>(cc_data);
-    
+
     auto deferred_accumulated_rfi = bland::ndarray_deferred([cc_data = cc_ptr, lower_threshold, upper_threshold]() {
         bland::ndarray spectrum_grid = cc_data->data();
         bland::ndarray rfi_flags     = cc_data->mask();
@@ -58,7 +58,7 @@ scan bliss::flag_spectral_kurtosis(scan fil_data, float lower_threshold, float u
     auto number_coarse_channels = fil_data.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
         auto cc = fil_data.read_coarse_channel(cc_index);
-        *cc = flag_spectral_kurtosis(*cc, lower_threshold, upper_threshold);
+        *cc     = flag_spectral_kurtosis(*cc, lower_threshold, upper_threshold);
     }
     return fil_data;
 }

--- a/bliss/python/CMakeLists.txt
+++ b/bliss/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-nanobind_add_module(pybliss NB_DOMAIN bliss pybliss.cpp)
+nanobind_add_module(pybliss pybliss.cpp)
 target_link_libraries(
   pybliss
   PUBLIC pybliss_core

--- a/notebooks/noise est ablations.ipynb
+++ b/notebooks/noise est ablations.ipynb
@@ -1,0 +1,879 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Failed to install bliss from installed module. Attempting build directory development module\n",
+      "Found a usable device\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<frozen importlib._bootstrap>:488: RuntimeWarning: nanobind: type 'ndarray' was already registered!\n",
+      "\n",
+      "<frozen importlib._bootstrap>:488: RuntimeWarning: nanobind: type 'dev' was already registered!\n",
+      "\n",
+      "<frozen importlib._bootstrap>:488: RuntimeWarning: nanobind: type 'datatype' was already registered!\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    import blissdedrift\n",
+    "except:\n",
+    "    print(\"Failed to install bliss from installed module. Attempting build directory development module\")\n",
+    "    import sys\n",
+    "    sys.path.append(\"../build/bliss/python\")\n",
+    "    import blissdedrift\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import numpy as np\n",
+    "%matplotlib widget\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import scipy.stats as spstat\n",
+    "from pprint import pp\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filpath = \"/home/nathan/datasets/voyager_2020_data/single_coarse_guppi_59046_80036_DIAG_VOYAGER-1_0011.rawspec.0000.h5\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "noise_stats = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cpu_cc = np.from_dlpack(cc.data)\n",
+    "\n",
+    "\n",
+    "noise_power_baseline = np.std(cpu_cc)\n",
+    "noise_floor_baseline = np.mean(cpu_cc)\n",
+    "\n",
+    "noise_stats[\"baseline\"] = {\n",
+    "    \"power\": noise_power_baseline,\n",
+    "    \"floor\": noise_floor_baseline\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "noise_slice = cpu_cc[:,250000:500000]\n",
+    "noise_power_slice = np.std(noise_slice)\n",
+    "noise_floor_slice = np.mean(noise_slice)\n",
+    "\n",
+    "noise_stats[\"slice\"] = {\n",
+    "    \"power\": noise_power_slice,\n",
+    "    \"floor\": noise_floor_slice\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vals, lower, upper = spstat.sigmaclip(cpu_cc)\n",
+    "\n",
+    "noise_power_vals = np.std(vals)\n",
+    "noise_floor_vals = np.mean(vals)\n",
+    "\n",
+    "noise_stats[\"sigmaclip_baseline\"] = {\n",
+    "    \"power\": noise_power_vals,\n",
+    "    \"floor\": noise_floor_vals\n",
+    "}\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'baseline': {'power': 3570070.5, 'floor': 5140684.0},\n",
+      " 'slice': {'power': 564954.3, 'floor': 5504788.0},\n",
+      " 'sigmaclip_baseline': {'power': 936291.56, 'floor': 5136734.0}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pp(noise_stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "# cc.noise_estimate(cc, noise_est_options)\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_baseline\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "INFO: spec kurtosis with M=16 and N=51\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_standard_flag = blissdedrift.flaggers.flag_spectral_kurtosis(cc, .05, 25)\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_standard_flag, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_sk\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_standard_flag = blissdedrift.flaggers.flag_filter_rolloff(cc, .25)\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_standard_flag, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_rolloff\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "iter 0:  mean=5140680.5    std=3570070.2\n",
+      "iter 1:  mean=5137039.5    std=937480.7\n",
+      "iter 2:  mean=5136866.5    std=936565.9\n",
+      "iter 3:  mean=5136866.5    std=936564.75\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_sigmaclip(cc, 35, 5, 5)\n",
+    "\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_sigmaclip, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_sigmaclip\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "INFO: spec kurtosis with M=16 and N=51\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_standard_flag = blissdedrift.flaggers.flag_filter_rolloff(cc, .2)\n",
+    "cc_standard_flag = blissdedrift.flaggers.flag_spectral_kurtosis(cc_standard_flag, .05, 25)\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_standard_flag, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_rolloff_sk\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "INFO: spec kurtosis with M=16 and N=51\n",
+      "iter 0:  mean=5140680.5    std=3570070.2\n",
+      "iter 1:  mean=5137039.5    std=937480.7\n",
+      "iter 2:  mean=5136866.5    std=936565.9\n",
+      "iter 3:  mean=5136866.5    std=936564.75\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_filter_rolloff(cc, .2)\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_spectral_kurtosis(cc_sigmaclip, .05, 25)\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_sigmaclip(cc_sigmaclip, 35, 5, 5)\n",
+    "\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_sigmaclip, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_rolloff_sk_sigmaclip\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "INFO: spec kurtosis with M=16 and N=51\n",
+      "iter 0:  mean=5140680.5    std=3570070.2\n",
+      "iter 1:  mean=5137039.5    std=937480.7\n",
+      "iter 2:  mean=5136866.5    std=936565.9\n",
+      "iter 3:  mean=5136866.5    std=936564.75\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_spectral_kurtosis(cc, .05, 25)\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_sigmaclip(cc_sigmaclip, 35, 5, 5)\n",
+    "\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_sigmaclip, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_sk_sigmaclip\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'baseline': {'power': 3570070.5, 'floor': 5140684.0},\n",
+      " 'slice': {'power': 564954.3, 'floor': 5504788.0},\n",
+      " 'sigmaclip_baseline': {'power': 936291.56, 'floor': 5136734.0},\n",
+      " 'bliss_baseline': {'power': 3570070.25, 'floor': 5140680.5},\n",
+      " 'bliss_sk': {'power': 937606.875, 'floor': 5137023.0},\n",
+      " 'bliss_rolloff': {'power': 4904291.0, 'floor': 5502934.5},\n",
+      " 'bliss_sigmaclip': {'power': 936564.75, 'floor': 5136866.5},\n",
+      " 'bliss_rolloff_sk': {'power': 569054.625, 'floor': 5497296.5},\n",
+      " 'bliss_rolloff_sk_sigmaclip': {'power': 566329.375, 'floor': 5497009.5},\n",
+      " 'bliss_sk_sigmaclip': {'power': 936558.6875, 'floor': 5136842.5}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pp(noise_stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc = blissdedrift.preprocess.equalize_passband_filter(cc, \"../gbt_pfb_response.f32\")\n",
+    "cpu_cc = np.from_dlpack(cc.data)\n",
+    "\n",
+    "\n",
+    "noise_power_baseline = np.std(cpu_cc)\n",
+    "noise_floor_baseline = np.mean(cpu_cc)\n",
+    "\n",
+    "noise_stats[\"corrected_baseline\"] = {\n",
+    "    \"power\": noise_power_baseline,\n",
+    "    \"floor\": noise_floor_baseline\n",
+    "}\n",
+    "\n",
+    "\n",
+    "noise_slice = cpu_cc[:,250000:500000]\n",
+    "noise_power_slice = np.std(noise_slice)\n",
+    "noise_floor_slice = np.mean(noise_slice)\n",
+    "\n",
+    "noise_stats[\"corrected_slice\"] = {\n",
+    "    \"power\": noise_power_slice,\n",
+    "    \"floor\": noise_floor_slice\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc = blissdedrift.preprocess.equalize_passband_filter(cc, \"../gbt_pfb_response.f32\")\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "# cc.noise_estimate(cc, noise_est_options)\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_corrected_baseline\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "INFO: spec kurtosis with M=16 and N=51\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc = blissdedrift.preprocess.equalize_passband_filter(cc, \"../gbt_pfb_response.f32\")\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_standard_flag = blissdedrift.flaggers.flag_spectral_kurtosis(cc, .05, 25)\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_standard_flag, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_corrected_sk\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n"
+     ]
+    }
+   ],
+   "source": [
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc = blissdedrift.preprocess.equalize_passband_filter(cc, \"../gbt_pfb_response.f32\")\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_standard_flag = blissdedrift.flaggers.flag_filter_rolloff(cc, .20)\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_standard_flag, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_corrected_rolloff\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "iter 0:  mean=5521440    std=3521909.8\n",
+      "iter 1:  mean=5517768.5    std=569019.6\n",
+      "iter 2:  mean=5517341.5    std=566825.94\n",
+      "iter 3:  mean=5517338    std=566811.9\n",
+      "iter 4:  mean=5517337.5    std=566814.9\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc = blissdedrift.preprocess.equalize_passband_filter(cc, \"../gbt_pfb_response.f32\")\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_sigmaclip(cc, 35, 5, 5)\n",
+    "\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_sigmaclip, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_corrected_sigmaclip\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: HDF5 looking for filter plugins in: \n",
+      "\t'/usr/lib/x86_64-linux-gnu/hdf5/serial/plugin\u0000'\n",
+      "INFO: spec kurtosis with M=16 and N=51\n",
+      "iter 0:  mean=5521440    std=3521909.8\n",
+      "iter 1:  mean=5517768.5    std=569019.6\n",
+      "iter 2:  mean=5517341.5    std=566825.94\n",
+      "iter 3:  mean=5517338    std=566811.9\n",
+      "iter 4:  mean=5517337.5    std=566814.9\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "sc = blissdedrift.scan(filpath)\n",
+    "cc = sc.read_coarse_channel(0)\n",
+    "cc = blissdedrift.preprocess.equalize_passband_filter(cc, \"../gbt_pfb_response.f32\")\n",
+    "cc.set_device(\"cuda:0\")\n",
+    "\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_spectral_kurtosis(cc, .05, 25)\n",
+    "cc_sigmaclip = blissdedrift.flaggers.flag_sigmaclip(cc_sigmaclip, 35, 5, 5)\n",
+    "\n",
+    "\n",
+    "noise_est_options = blissdedrift.estimators.noise_power_estimate_options()\n",
+    "noise_est_options.masked_estimate = True\n",
+    "\n",
+    "cc_noise_est = blissdedrift.estimators.estimate_noise_power(cc_sigmaclip, noise_est_options)\n",
+    "\n",
+    "noise_stats[\"bliss_corrected_sk_sigmaclip\"] = {\n",
+    "    \"power\": cc_noise_est.noise_power,\n",
+    "    \"floor\": cc_noise_est.noise_floor\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'baseline': {'power': 3570070.5, 'floor': 5140684.0},\n",
+      " 'slice': {'power': 564954.3, 'floor': 5504788.0},\n",
+      " 'sigmaclip_baseline': {'power': 936291.56, 'floor': 5136734.0},\n",
+      " 'bliss_baseline': {'power': 3570070.25, 'floor': 5140680.5},\n",
+      " 'bliss_sk': {'power': 937606.875, 'floor': 5137023.0},\n",
+      " 'bliss_rolloff': {'power': 4904291.0, 'floor': 5502934.5},\n",
+      " 'bliss_sigmaclip': {'power': 936564.75, 'floor': 5136866.5},\n",
+      " 'bliss_rolloff_sk': {'power': 569054.625, 'floor': 5497296.5},\n",
+      " 'bliss_rolloff_sk_sigmaclip': {'power': 566329.375, 'floor': 5497009.5},\n",
+      " 'bliss_sk_sigmaclip': {'power': 936558.6875, 'floor': 5136842.5},\n",
+      " 'corrected_baseline': {'power': 3521909.5, 'floor': 5521433.0},\n",
+      " 'corrected_slice': {'power': 567031.25, 'floor': 5527145.0},\n",
+      " 'bliss_corrected_baseline': {'power': 3521909.75, 'floor': 5521440.0},\n",
+      " 'bliss_corrected_sk': {'power': 569222.6875, 'floor': 5517762.0},\n",
+      " 'bliss_corrected_rolloff': {'power': 4523199.5, 'floor': 5526402.5},\n",
+      " 'bliss_corrected_sigmaclip': {'power': 566814.875, 'floor': 5517337.5},\n",
+      " 'bliss_corrected_sk_sigmaclip': {'power': 566800.375, 'floor': 5517325.5}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pp(noise_stats)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, Math\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\t\t\t\t|rolloff| SK\t|σ-clip\t|pfbcomp| power     | floor\t\n",
+      "-----------------------------------------------------------\n",
+      "full spectrum baseline \t\t| \t| \t| \t| \t| 3570070.5 | 5140684.0\n",
+      "slice noise baseline \t\t| \t| \t| \t| \t|  564954.3 | 5504788.0\n",
+      " \t\t\t\t| \t| \t| ✓\t| \t|  936291.6 | 5136734.0\n",
+      "bliss baseline \t\t\t| \t| \t| \t| \t| 3570070.2 | 5140680.5\n",
+      " \t\t\t\t| ✓\t| \t| \t| \t| 4904291.0 | 5502934.5\n",
+      " \t\t\t\t| \t| ✓\t| \t| \t|  937606.9 | 5137023.0\n",
+      " \t\t\t\t| \t| \t| ✓\t| \t|  936564.8 | 5136866.5\n",
+      " \t\t\t\t| ✓\t| ✓\t| \t| \t|  569054.6 | 5497296.5\n",
+      " \t\t\t\t| \t| ✓\t| ✓\t| \t|  936558.7 | 5136842.5\n",
+      " \t\t\t\t| ✓\t| ✓\t| ✓\t| \t|  566329.4 | 5497009.5\n",
+      "-----------------------------------------------------------\n",
+      "corrected spectrum baseline \t| \t| \t| \t| ✓\t| 3521909.5 | 5521433.0\n",
+      "corrected spectrum slice \t| \t| \t| \t| ✓\t|  567031.2 | 5527145.0\n",
+      "corrected spectrum bliss \t| \t| \t| \t| ✓\t| 3521909.8 | 5521440.0\n",
+      " \t\t\t\t| ✓\t| \t| \t| ✓\t| 4523199.5 | 5526402.5\n",
+      " \t\t\t\t| \t| ✓\t| \t| ✓\t|  569222.7 | 5517762.0\n",
+      " \t\t\t\t| \t| \t| ✓\t| ✓\t|  566814.9 | 5517337.5\n",
+      " \t\t\t\t| \t| ✓\t| ✓\t| ✓\t|  566800.4 | 5517325.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "print(\"\\t\\t\\t\\t|rolloff| SK\\t|σ-clip\\t|pfbcomp| power     | floor\\t\")\n",
+    "print(\"-----------------------------------------------------------\")\n",
+    "print(f\"full spectrum baseline \\t\\t| \\t| \\t| \\t| \\t| {noise_stats[\"baseline\"][\"power\"]:9.1f} | {noise_stats[\"baseline\"][\"floor\"]:9.1f}\")\n",
+    "print(f\"slice noise baseline \\t\\t| \\t| \\t| \\t| \\t| {noise_stats[\"slice\"][\"power\"]:9.1f} | {noise_stats[\"slice\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| \\t| \\t| ✓\\t| \\t| {noise_stats[\"sigmaclip_baseline\"][\"power\"]:9.1f} | {noise_stats[\"sigmaclip_baseline\"][\"floor\"]:8.1f}\")\n",
+    "\n",
+    "print(f\"bliss baseline \\t\\t\\t| \\t| \\t| \\t| \\t| {noise_stats[\"bliss_baseline\"][\"power\"]:9.1f} | {noise_stats[\"bliss_baseline\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| ✓\\t| \\t| \\t| \\t| {noise_stats[\"bliss_rolloff\"][\"power\"]:9.1f} | {noise_stats[\"bliss_rolloff\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| \\t| ✓\\t| \\t| \\t| {noise_stats[\"bliss_sk\"][\"power\"]:9.1f} | {noise_stats[\"bliss_sk\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| \\t| \\t| ✓\\t| \\t| {noise_stats[\"bliss_sigmaclip\"][\"power\"]:9.1f} | {noise_stats[\"bliss_sigmaclip\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| ✓\\t| ✓\\t| \\t| \\t| {noise_stats[\"bliss_rolloff_sk\"][\"power\"]:9.1f} | {noise_stats[\"bliss_rolloff_sk\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| \\t| ✓\\t| ✓\\t| \\t| {noise_stats[\"bliss_sk_sigmaclip\"][\"power\"]:9.1f} | {noise_stats[\"bliss_sk_sigmaclip\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| ✓\\t| ✓\\t| ✓\\t| \\t| {noise_stats[\"bliss_rolloff_sk_sigmaclip\"][\"power\"]:9.1f} | {noise_stats[\"bliss_rolloff_sk_sigmaclip\"][\"floor\"]:8.1f}\")\n",
+    "\n",
+    "print(\"-----------------------------------------------------------\")\n",
+    "\n",
+    "print(f\"corrected spectrum baseline \\t| \\t| \\t| \\t| ✓\\t| {noise_stats[\"corrected_baseline\"][\"power\"]:9.1f} | {noise_stats[\"corrected_baseline\"][\"floor\"]:8.1f}\")\n",
+    "print(f\"corrected spectrum slice \\t| \\t| \\t| \\t| ✓\\t| {noise_stats[\"corrected_slice\"][\"power\"]:9.1f} | {noise_stats[\"corrected_slice\"][\"floor\"]:8.1f}\")\n",
+    "print(f\"corrected spectrum bliss \\t| \\t| \\t| \\t| ✓\\t| {noise_stats[\"bliss_corrected_baseline\"][\"power\"]:9.1f} | {noise_stats[\"bliss_corrected_baseline\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| ✓\\t| \\t| \\t| ✓\\t| {noise_stats[\"bliss_corrected_rolloff\"][\"power\"]:9.1f} | {noise_stats[\"bliss_corrected_rolloff\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| \\t| ✓\\t| \\t| ✓\\t| {noise_stats[\"bliss_corrected_sk\"][\"power\"]:9.1f} | {noise_stats[\"bliss_corrected_sk\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| \\t| \\t| ✓\\t| ✓\\t| {noise_stats[\"bliss_corrected_sigmaclip\"][\"power\"]:9.1f} | {noise_stats[\"bliss_corrected_sigmaclip\"][\"floor\"]:8.1f}\")\n",
+    "print(f\" \\t\\t\\t\\t| \\t| ✓\\t| ✓\\t| ✓\\t| {noise_stats[\"bliss_corrected_sk_sigmaclip\"][\"power\"]:9.1f} | {noise_stats[\"bliss_corrected_sk_sigmaclip\"][\"floor\"]:8.1f}\")\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\checkmark$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Math object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Math(r\"\\checkmark\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.013674684145064"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "3570070.5/3521909.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (1676554632.py, line 1)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  Cell \u001b[0;32mIn[28], line 1\u001b[0;36m\u001b[0m\n\u001b[0;31m    p = 1/16 777 216\u001b[0m\n\u001b[0m             ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = 1/16 777 216\n",
+    "p\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.special import erfc\n",
+    "\n",
+    "def qfunc(x):\n",
+    "    return 0.5 * erfc(x / np.sqrt(2))\n",
+    "\n",
+    "x = 6\n",
+    "result = qfunc(x)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".devenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This adds a sigmaclip flagger and fixes spectral kurtosis by exposing `d` (the shape parameter of the gamma distribution describing data and setting the default value do be 2 (which is a change from the previous default value of 1) to match the distribution shape of dual-pol spectrum we most often see