### PR TITLE
Validate flaring after |H| compensation

### DIFF
--- a/bliss/core/include/core/scan.hpp
+++ b/bliss/core/include/core/scan.hpp
@@ -80,6 +80,8 @@ class scan {
      */
     std::list<hit> hits();
 
+    std::pair<float, float> get_drift_range();
+
     bland::ndarray::dev device();
     void set_device(bland::ndarray::dev &device, bool verbose=true);
     void set_device(std::string_view device, bool verbose=true);

--- a/bliss/drift_search/filter_hits.cpp
+++ b/bliss/drift_search/filter_hits.cpp
@@ -21,8 +21,20 @@ std::list<hit> bliss::filter_hits(std::list<hit> hits, filter_options options) {
                 remove_hit = true;
             }
         }
-        if (current_hit->rfi_counts[flag_values::sigma_clip] < std::fabs(current_hit->integrated_channels) * .1) {
-            remove_hit = true;
+        if (options.filter_sigmaclip) {
+            if (current_hit->rfi_counts[flag_values::sigma_clip] < std::fabs(current_hit->integrated_channels) * options.minimum_percent_sigmaclip) {
+                remove_hit = true;
+            }
+        }
+        if (options.filter_high_sk) {
+            if (current_hit->rfi_counts[flag_values::high_spectral_kurtosis] < std::fabs(current_hit->integrated_channels) * options.minimum_percent_high_sk) {
+                remove_hit = true;
+            }
+        }
+        if (options.filter_low_sk) {
+            if (current_hit->rfi_counts[flag_values::low_spectral_kurtosis] > std::fabs(current_hit->integrated_channels) * options.maximum_percent_low_sk) {
+                remove_hit = true;
+            }
         }
         if (remove_hit) {
             current_hit = hits.erase(current_hit);

--- a/bliss/drift_search/include/drift_search/filter_hits.hpp
+++ b/bliss/drift_search/include/drift_search/filter_hits.hpp
@@ -10,6 +10,15 @@ namespace bliss {
 
 struct filter_options {
     bool filter_zero_drift = true;
+
+    bool filter_sigmaclip = true;
+    float minimum_percent_sigmaclip = 0.1;
+
+    bool filter_high_sk = false;
+    float minimum_percent_high_sk = 0.1;
+
+    bool filter_low_sk = false;
+    float maximum_percent_low_sk = 0.1;
 };
 
 std::list<hit> filter_hits(std::list<hit>, filter_options options);

--- a/bliss/drift_search/include/drift_search/pydrift_search.hpp
+++ b/bliss/drift_search/include/drift_search/pydrift_search.hpp
@@ -111,7 +111,13 @@ void bind_pydrift_search(nb::module_ m) {
 
     nb::class_<bliss::filter_options>(m, "filter_options")
     .def(nb::init<>())
-    .def_rw("filter_zero_drift", &bliss::filter_options::filter_zero_drift);
+    .def_rw("filter_zero_drift", &bliss::filter_options::filter_zero_drift)
+    .def_rw("filter_sigmaclip", &bliss::filter_options::filter_sigmaclip)
+    .def_rw("minimum_percent_sigmaclip", &bliss::filter_options::minimum_percent_sigmaclip)
+    .def_rw("filter_high_sk", &bliss::filter_options::filter_high_sk)
+    .def_rw("minimum_percent_high_sk", &bliss::filter_options::minimum_percent_high_sk)
+    .def_rw("filter_low_sk", &bliss::filter_options::filter_low_sk)
+    .def_rw("maximum_percent_low_sk", &bliss::filter_options::maximum_percent_low_sk);
 
     m.def("filter_hits", nb::overload_cast<std::list<bliss::hit>, bliss::filter_options>(&bliss::filter_hits));
     m.def("filter_hits", nb::overload_cast<bliss::coarse_channel, bliss::filter_options>(&bliss::filter_hits));

--- a/bliss/file_types/dat_file.cpp
+++ b/bliss/file_types/dat_file.cpp
@@ -92,6 +92,7 @@ void bliss::write_scan_hits_to_dat_file(scan scan_with_hits, std::string_view fi
     auto raj = scan_with_hits.src_raj();
     auto dej = scan_with_hits.src_dej();
     auto tstart = scan_with_hits.tstart();
+    auto drift_range = scan_with_hits.get_drift_range();
 
     std::string file_path_id{"n/a"};
     try {
@@ -128,7 +129,7 @@ void bliss::write_scan_hits_to_dat_file(scan scan_with_hits, std::string_view fi
                         formatted_dej,
                         scan_with_hits.tsamp(),
                         scan_with_hits.foff()*1e6,
-                        "n/a",
+                        drift_range.second,
                         scan_with_hits.ntsteps()*scan_with_hits.tsamp());
     write(output_file._fd, header.c_str(), header.size());
     auto table_contents = format_hits_to_dat_list(hits);

--- a/bliss/preprocess/include/preprocess/passband_static_equalize.hpp
+++ b/bliss/preprocess/include/preprocess/passband_static_equalize.hpp
@@ -11,20 +11,20 @@ namespace bliss {
 
     bland::ndarray gen_coarse_channel_response(int fine_per_coarse, int num_coarse_channels=2048, int taps_per_channel=4, std::string window="hamming", std::string device_str="cpu");
 
-    coarse_channel equalize_passband_filter(coarse_channel cc, bland::ndarray h);
+    coarse_channel equalize_passband_filter(coarse_channel cc, bland::ndarray h, bool validate=false);
 
-    coarse_channel equalize_passband_filter(coarse_channel cc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32);
+    coarse_channel equalize_passband_filter(coarse_channel cc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32, bool validate=false);
 
-    scan equalize_passband_filter(scan sc, bland::ndarray h);
+    scan equalize_passband_filter(scan sc, bland::ndarray h, bool validate=false);
 
-    scan equalize_passband_filter(scan sc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32);
+    scan equalize_passband_filter(scan sc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32, bool validate=false);
 
-    observation_target equalize_passband_filter(observation_target ot, bland::ndarray h);
+    observation_target equalize_passband_filter(observation_target ot, bland::ndarray h, bool validate=false);
 
-    observation_target equalize_passband_filter(observation_target ot, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32);
+    observation_target equalize_passband_filter(observation_target ot, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32, bool validate=false);
 
-    cadence equalize_passband_filter(cadence ca, bland::ndarray h);
+    cadence equalize_passband_filter(cadence ca, bland::ndarray h, bool validate=false);
 
-    cadence equalize_passband_filter(cadence ca, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32);
+    cadence equalize_passband_filter(cadence ca, std::string_view h_resp_filepath, bland::ndarray::datatype dtype=bland::ndarray::datatype::float32, bool validate=false);
 
 }

--- a/bliss/preprocess/include/preprocess/pypreprocess.hpp
+++ b/bliss/preprocess/include/preprocess/pypreprocess.hpp
@@ -27,17 +27,17 @@ void bind_pypreprocess(nb::module_ m) {
             "window"_a     = "hamming",
             "device_str"_a = "cpu");
 
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::coarse_channel, bland::ndarray>(bliss::equalize_passband_filter), "coarse_channel"_a, "response"_a);
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::coarse_channel, std::string_view, bland::ndarray::datatype>(bliss::equalize_passband_filter), "coarse_channel"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"));
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::coarse_channel, bland::ndarray, bool>(bliss::equalize_passband_filter), "coarse_channel"_a, "response"_a, "validate"_a=false);
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::coarse_channel, std::string_view, bland::ndarray::datatype, bool>(bliss::equalize_passband_filter), "coarse_channel"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"), "validate"_a=false);
 
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::scan, bland::ndarray>(bliss::equalize_passband_filter), "scan"_a, "response"_a);
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::scan, std::string_view, bland::ndarray::datatype>(bliss::equalize_passband_filter), "scan"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"));
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::scan, bland::ndarray, bool>(bliss::equalize_passband_filter), "scan"_a, "response"_a, "validate"_a=false);
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::scan, std::string_view, bland::ndarray::datatype, bool>(bliss::equalize_passband_filter), "scan"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"), "validate"_a=false);
 
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::observation_target, bland::ndarray>(bliss::equalize_passband_filter), "observation_target"_a, "response"_a);
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::observation_target, std::string_view, bland::ndarray::datatype>(bliss::equalize_passband_filter), "observation_target"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"));
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::observation_target, bland::ndarray, bool>(bliss::equalize_passband_filter), "observation_target"_a, "response"_a, "validate"_a=false);
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::observation_target, std::string_view, bland::ndarray::datatype, bool>(bliss::equalize_passband_filter), "observation_target"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"), "validate"_a=false);
 
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::cadence, bland::ndarray>(bliss::equalize_passband_filter), "cadence"_a, "response"_a);
-      m.def("equalize_passband_filter", nb::overload_cast<bliss::cadence, std::string_view, bland::ndarray::datatype>(bliss::equalize_passband_filter), "cadence"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"));
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::cadence, bland::ndarray, bool>(bliss::equalize_passband_filter), "cadence"_a, "response"_a, "validate"_a=false);
+      m.def("equalize_passband_filter", nb::overload_cast<bliss::cadence, std::string_view, bland::ndarray::datatype, bool>(bliss::equalize_passband_filter), "cadence"_a, "response_path"_a, "response_dtype"_a=bland::ndarray::datatype("float"), "validate"_a=false);
 
       m.def("normalize", nb::overload_cast<bliss::coarse_channel>(bliss::normalize));
       m.def("normalize", nb::overload_cast<bliss::scan>(bliss::normalize));

--- a/bliss/preprocess/passband_static_equalize.cpp
+++ b/bliss/preprocess/passband_static_equalize.cpp
@@ -106,54 +106,88 @@ bland::ndarray bliss::gen_coarse_channel_response(int fine_per_coarse, int num_c
     return H;
 }
 
-coarse_channel bliss::equalize_passband_filter(coarse_channel cc, bland::ndarray h) {
-    h = h.to(cc.device());
-    cc.set_data(bland::divide(cc.data(), h));
+coarse_channel bliss::equalize_passband_filter(coarse_channel cc, bland::ndarray H, bool validate) {
+    // Validate that the mean of the passband is 2x the mean of the cutoff
+    // TODO: this could check the ratios of the filter response and force them to be equal
+
+    if (validate) {
+        auto spectra = cc.data();
+        auto num_channels = spectra.size(1);
+        bland::ndarray spectra_passband = bland::mean(spectra.slice(bland::slice_spec{1, num_channels/2 - 100, num_channels / 2 + 100}));
+        bland::ndarray spectra_cutoff_lower = bland::mean(spectra.slice(bland::slice_spec{1, 0, 50}));
+        bland::ndarray spectra_cutoff_upper = bland::mean(spectra.slice(bland::slice_spec{1, -50, -1}));
+        auto spectra_passband_mean = spectra_passband.scalarize<float>();
+        auto spectra_cutoff_upper_mean = spectra_cutoff_lower.scalarize<float>();
+        auto spectra_cutoff_lower_mean = spectra_cutoff_upper.scalarize<float>();
+        auto spectra_cutoff_mean = (spectra_cutoff_upper_mean + spectra_cutoff_lower_mean) / 2.0f;
+
+        // H should be one dimensional with the same number of channels as given spectra
+        bland::ndarray H_passband = bland::mean(H.slice(bland::slice_spec{0, num_channels/2 - 100, num_channels / 2 + 100}));
+        bland::ndarray H_cutoff_lower = bland::mean(H.slice(bland::slice_spec{0, 0, 50}));
+        bland::ndarray H_cutoff_upper = bland::mean(H.slice(bland::slice_spec{0, -50, -1}));
+        auto H_passband_mean = H_passband.scalarize<float>();
+        auto H_cutoff_upper_mean = H_cutoff_lower.scalarize<float>();
+        auto H_cutoff_lower_mean = H_cutoff_upper.scalarize<float>();
+        auto H_ratio = H_passband_mean / ((H_cutoff_upper_mean + H_cutoff_lower_mean) / 2.0f);
+
+        if (spectra_cutoff_mean > 1.05 * (spectra_passband_mean / H_ratio)) {
+            fmt::print("WARN: the ratio ({}) of power between the passband ({}) and cutoff ({}) for data does not "
+                       "match given ratio of power in the given filter response ({}). This is potentially a data "
+                       "quality issue inherent to recording that will cause flared edges after correction which can "
+                       "lead to false positives.\n",
+                       spectra_passband_mean / spectra_cutoff_mean,
+                       spectra_passband_mean,
+                       spectra_cutoff_mean,
+                       H_ratio);
+        }
+    }
+    H = H.to(cc.device());
+    cc.set_data(bland::divide(cc.data(), H));
     return cc;
 }
 
-coarse_channel bliss::equalize_passband_filter(coarse_channel cc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype) {
+coarse_channel bliss::equalize_passband_filter(coarse_channel cc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype, bool validate) {
     auto h = bland::read_from_file(h_resp_filepath, dtype);
-    return equalize_passband_filter(cc, h);
+    return equalize_passband_filter(cc, h, validate);
 }
 
 
-scan bliss::equalize_passband_filter(scan sc, bland::ndarray h) {
+scan bliss::equalize_passband_filter(scan sc, bland::ndarray h, bool validate) {
     auto number_coarse_channels = sc.get_number_coarse_channels();
     for (auto cc_index = 0; cc_index < number_coarse_channels; ++cc_index) {
-        sc.add_coarse_channel_transform([h](coarse_channel cc) { return equalize_passband_filter(cc, h); });
+        sc.add_coarse_channel_transform([h, validate](coarse_channel cc) { return equalize_passband_filter(cc, h, validate); });
         // auto cc = sc.read_coarse_channel(cc_index);
         // *cc = equalize_passband_filter(*cc, h);
     }
     return sc;
 }
 
-scan bliss::equalize_passband_filter(scan sc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype) {
+scan bliss::equalize_passband_filter(scan sc, std::string_view h_resp_filepath, bland::ndarray::datatype dtype, bool validate) {
     auto h = bland::read_from_file(h_resp_filepath, dtype);
-    return equalize_passband_filter(sc, h);
+    return equalize_passband_filter(sc, h, validate);
 }
 
-observation_target bliss::equalize_passband_filter(observation_target ot, bland::ndarray h) {
+observation_target bliss::equalize_passband_filter(observation_target ot, bland::ndarray h, bool validate) {
     for (auto &scan_data : ot._scans) {
-        scan_data = equalize_passband_filter(scan_data, h);
+        scan_data = equalize_passband_filter(scan_data, h, validate);
     }
     return ot;
 }
 
-observation_target bliss::equalize_passband_filter(observation_target ot, std::string_view h_resp_filepath, bland::ndarray::datatype dtype) {
+observation_target bliss::equalize_passband_filter(observation_target ot, std::string_view h_resp_filepath, bland::ndarray::datatype dtype, bool validate) {
     auto h = bland::read_from_file(h_resp_filepath, dtype);
     h = h.to(ot.device());
-    return equalize_passband_filter(ot, h);
+    return equalize_passband_filter(ot, h, validate);
 }
 
-cadence bliss::equalize_passband_filter(cadence ca, bland::ndarray h) {
+cadence bliss::equalize_passband_filter(cadence ca, bland::ndarray h, bool validate) {
     for (auto &target : ca._observations) {
-        target = equalize_passband_filter(target, h);
+        target = equalize_passband_filter(target, h, validate);
     }
     return ca;
 }
 
-cadence bliss::equalize_passband_filter(cadence ca, std::string_view h_resp_filepath, bland::ndarray::datatype dtype) {
+cadence bliss::equalize_passband_filter(cadence ca, std::string_view h_resp_filepath, bland::ndarray::datatype dtype, bool validate) {
     auto h = bland::read_from_file(h_resp_filepath, dtype);
-    return equalize_passband_filter(ca, h);
+    return equalize_passband_filter(ca, h, validate);
 }

--- a/bliss/python/blissdedrift/plot_utils/_encodings.py
+++ b/bliss/python/blissdedrift/plot_utils/_encodings.py
@@ -13,7 +13,7 @@ def get_hits_list(pipeline_object, origin_name=None):
             # Try to come up with a good one, but it probably doesn't matter
             origin_name = f"{pipeline_object.source_name}:{pipeline_object.src_dej:1.4f},{pipeline_object.src_raj:1.4f}:{pipeline_object.tstart:1.4f}"
         # This should succeed for `coarse_channel` and `scan` which can directly query `hits()`
-        hits = pipeline_object.hits()
+        hits = pipeline_object.hits
         hits_list = [{
             "start_freq_MHz": hit.start_freq_MHz, "drift_rate_Hz_per_sec": hit.drift_rate_Hz_per_sec,
             "SNR": hit.snr, "power": hit.power, "bandwidth_Hz": hit.bandwidth,


### PR DESCRIPTION
Adds a validation check for equalization causing flaring for low Vrms values with excessive quantization noise around the cutoff region.

This closes #89 

Also add some more checks to hit filtering, make them all configurable through the hit filter options, and pipe it through cli and pybind (closes #90)

Also adds a minor fix to dat-file writing where the max drift range was not being output. Now it is output.